### PR TITLE
specify package location and license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Parker Hicks", email = "parker.hicks@cuanschutz.edu"},
     {name = "Faisal Alquaddoomi", email = "faisal.alquaddoomi@cuanschutz.edu"},
 ]
-license = {file = "LICENSE"}
+license = "BSD-3-Clause"
 keywords = ["cli", "metadata", "database"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -29,6 +29,12 @@ members = ["packages/core", "packages/cli"]
 [tool.uv.sources]
 metahq-core = { workspace = true }
 metahq-cli = { workspace = true }
+
+[tool.setuptools.packages.find]
+where = ["packages"] 
+include = ["core", "cli"]
+exclude = ["demo", "results", "run", "data"]
+namespaces = false 
 
 [project.scripts]
 metahq = "metahq_cli.main:main"


### PR DESCRIPTION
# What
Specified package location for `setuptools`.

# Why
I tested the install on another mac (it worked on one mac before and a linux machine), but this time `pip` and `uv` could not find the packages and had a problem with the license definition.

# How
- Specified the package location for `setuptools`
- Included the license definition as a string instead of a reference to the `LICENSE` file.