### PR TITLE
Force spinner activation when loading ontology relations

### DIFF
--- a/packages/core/src/metahq_core/curations/annotation_converter.py
+++ b/packages/core/src/metahq_core/curations/annotation_converter.py
@@ -181,17 +181,14 @@ class AnnotationsConverter:
         if total is None:
             total = len(self.to_terms)
 
-        if total > WARNING_SIZE:
-            relation_map = progress_wrapper(
-                f"{relatives}...",
-                verbose=self.verbose,
-                total=total,
-                func=opt[relatives],
-                subset=self.to_terms,
-                padding="    ",
-            )
-        else:
-            relation_map = opt[relatives](subset=self.to_terms)
+        relation_map = progress_wrapper(
+            f"{relatives}...",
+            verbose=self.verbose,
+            total=total,
+            func=opt[relatives],
+            subset=self.to_terms,
+            padding="    ",
+        )
 
         return merge_list_values(relation_map)
 


### PR DESCRIPTION
# What
Force spinner to appear when loading term: term ontology relations.

# Why
Before, the number of queried terms needed to reach a large threshold for the spinner to activate because it was a long process. However, it's much faster now and also doesn't need to be variable.

# How
Removed the if/else statement checking if a threshold is met. Spinner will now activate every time.