### PR TITLE
fixed typo in elderly_adult encoding

### DIFF
--- a/packages/core/src/metahq_core/util/supported.py
+++ b/packages/core/src/metahq_core/util/supported.py
@@ -7,7 +7,7 @@ Functions beginning with an underscore are intended to be called through the
 Author: Parker Hicks
 Date: 2025-04-15
 
-Last updated: 2025-11-24 by Parker Hicks
+Last updated: 2026-02-02 by Parker Hicks
 """
 
 from pathlib import Path


### PR DESCRIPTION
# What
Fixed typo in "elderly_adult" encoding. Closes #57 . All tests passing and `metahq retrieve` runs as expected.