### PR TITLE
removed unused species

### DIFF
--- a/packages/core/src/metahq_core/util/supported.py
+++ b/packages/core/src/metahq_core/util/supported.py
@@ -141,8 +141,6 @@ def species_map() -> dict[str, str]:
     return {
         "human": "homo sapiens",
         "mouse": "mus musculus",
-        "worm": "caenorhabditis elegans",
-        "fly": "drosophila melanogaster",
         "zebrafish": "danio rerio",
         "rat": "rattus norvegicus",
     }


### PR DESCRIPTION
# What
Removes species names from `metahq_core/util/supported.py` that were filtered out in the most recent MetaHQ data package version (v1.0.1). Worm and fly were removed.

Closes #59 

# PR Checklist
- [x] All tests passing.
- [x] `metahq retrieve` works as expected