### PR TITLE
Minor documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Latest database: 17663086](https://zenodo.org/badge/DOI/10.5281/zenodo.17663086.svg)](https://doi.org/10.5281/zenodo.17663086)
 
 A platform for harmonizing and distributing community-curated high-quality metadata of public omics samples and datasets.
+See our preprint at [https://arxiv.org/abs/2602.07805](https://arxiv.org/abs/2602.07805).
 
 ## Status
 

--- a/docs/about/citation.md
+++ b/docs/about/citation.md
@@ -1,5 +1,6 @@
 # Citing MetaHQ
 
+The preprint for MetaHQ can be found at [https://arxiv.org/abs/2602.07805](https://arxiv.org/abs/2602.07805).
 To cite MetaHQ please use the following reference:
 
 ```

--- a/docs/about/citation.md
+++ b/docs/about/citation.md
@@ -2,7 +2,17 @@
 
 To cite MetaHQ please use the following reference:
 
-`tmp reference`
+```
+@misc{hicks2026metahqharmonizedhighqualitymetadata,
+      title={MetaHQ: Harmonized, high-quality metadata annotations of public omics samples and studies},
+      author={Parker Hicks and Lydia E Valtadoros and Christopher A Mancuso and Faisal Alquadoomi and Kayla A Johnson and Sneha Sundar and Arjun Krishnan},
+      year={2026},
+      eprint={2602.07805},
+      archivePrefix={arXiv},
+      primaryClass={q-bio.GN},
+      url={https://arxiv.org/abs/2602.07805},
+}
+```
 
 ## Citing individual annotation sets
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -8,7 +8,7 @@ The foundational library for the CLI providing data structures and utilities for
 
 ### metahq-cli
 
-A command-line interface built on top of MetaHQ Core, providing easy-to-use commands for retrieving biomedical sample and study annotations.
+A command-line interface built on top of `metahq-core`, providing easy-to-use commands for retrieving biomedical sample and study annotations.
 
 ## Project Status
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -24,7 +24,7 @@ metahq retrieve tissues --terms "UBERON:0000948,UBERON:0000955" \
 
 See the [retrieve documentation](../packages/cli/commands/retrieve.md) for more details.
 
-## Search
+## Ontology term ID search
 
 Tissue and disease queries require standardized ontology term ID inputs. The following command will identify the top five most similar
 MONDO disease ontology term IDs to "heart attack".

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,10 @@ Welcome to the MetaHQ documentation!
 - [CLI User Guide](user-guide/setup.md)
 - [Contributing](contribute/index.md)
 
+## Paper
+
+The preprint for MetaHQ can be found at [https://arxiv.org/abs/2602.07805](https://arxiv.org/abs/2602.07805).
+
 ## Getting Help
 
 Open an issue on [GitHub](https://github.com/krishnanlab/meta-hq) if you encounter any issues or have questions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,8 @@ theme:
     - navigation.instant
     - navigation.tracking
     - navigation.tabs
+    - navigation.path
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - search.suggest
     - search.highlight


### PR DESCRIPTION
# What
Minor updates to the documentation post-arXiv submission.

# Why
- Closes: #77

# Changes made
- Updated the citation under the `About` tab to point to the arXiv submission
- Added a more descriptive subtitle for the `metahq search` example under `Getting Started` `Quick Start` tab
- Fixed a typo under the description of `metahq-cli` in the `Developer` `Package Overview` tab

# Notes
- This does not alter the codebase of the packages
  - We do not need to release new versions of `metahq-core` or `metahq-cli` with this update
- I will build a new readthedocs version under the  `v1.0.0` tag after this is merged
