### PR TITLE
Adds PATO IDs as valid sex retrieval term inputs 

### DIFF
--- a/docs/user-guide/retrieve.md
+++ b/docs/user-guide/retrieve.md
@@ -132,7 +132,9 @@ Retrieve sex annotations.
 ### Additional Options
 
 - `--terms TEXT`: Comma-separated sex terms.
-    - Available terms: `male`, `female`
+    - Available terms:
+        - Female: `female`, `F`, `PATO:0000383`
+        - Male: `male`, `M`, `PATO:0000384`
 
 ### Examples
 

--- a/packages/cli/src/metahq_cli/retrieval_builder.py
+++ b/packages/cli/src/metahq_cli/retrieval_builder.py
@@ -330,15 +330,17 @@ class Builder:
         return CurationConfig(mode, _terms, ontology="sex")
 
     def _map_sex_to_id(self, terms: list[str]):
-        """Map male to M and female to F if passed."""
-        opt = {"male": "M", "female": "F"}
+        """Map male or PATO:0000384 to M and female or PATO:0000383 to F if passed."""
+        opt = {"male": "M", "female": "F", "PATO:0000384": "M", "PATO:0000383": "F"}
 
         result = []
         for term in terms:
-            if term in ["male", "female"]:
+            if term in opt:
                 result.append(opt[term])
-            else:
+            elif term in opt.values():
                 result.append(term)
+            else:
+                self.log.warning("Invalid input: %s. Skipping...", term)
 
         return result
 

--- a/packages/cli/tests/test_Builder.py
+++ b/packages/cli/tests/test_Builder.py
@@ -151,7 +151,9 @@ class TestBuilder:
 
     @patch("metahq_cli.retrieval_builder.check_filter")
     @patch("metahq_cli.retrieval_builder.check_license")
-    def test_query_config_validates_filters(self, mock_check_license, mock_check, builder):
+    def test_query_config_validates_filters(
+        self, mock_check_license, mock_check, builder
+    ):
         """test query_config validates all filter parameters"""
         filters = {"species": "human", "ecode": "expert", "tech": "rnaseq"}
 
@@ -164,7 +166,9 @@ class TestBuilder:
 
     @patch("metahq_cli.retrieval_builder.check_filter")
     @patch("metahq_cli.retrieval_builder.check_license")
-    def test_query_config_default_license(self, mock_check_license, mock_check, builder):
+    def test_query_config_default_license(
+        self, mock_check_license, mock_check, builder
+    ):
         """test query_config defaults license to 'any'"""
         filters = {"species": "human", "ecode": "expert", "tech": "rnaseq"}
 
@@ -179,14 +183,18 @@ class TestBuilder:
         """test query_config stores the supplied license in QueryConfig"""
         filters = {"species": "human", "ecode": "expert", "tech": "rnaseq"}
 
-        result = builder.query_config("geo", "tissue", "sample", filters, license="permissive")
+        result = builder.query_config(
+            "geo", "tissue", "sample", filters, license="permissive"
+        )
 
         assert result.license == "permissive"
         mock_check_license.assert_called_once_with("permissive")
 
     @patch("metahq_cli.retrieval_builder.check_filter")
     @patch("metahq_cli.retrieval_builder.check_license")
-    def test_query_config_calls_check_license(self, mock_check_license, mock_check, builder):
+    def test_query_config_calls_check_license(
+        self, mock_check_license, mock_check, builder
+    ):
         """test query_config calls check_license with the supplied value"""
         filters = {"species": "human", "ecode": "expert", "tech": "rnaseq"}
 
@@ -201,7 +209,9 @@ class TestBuilder:
         from pathlib import Path
 
         outdir = Path("/tmp/my_results")
-        result = builder.output_config(outdir, "parquet", "sample", "sample", "test_attr")
+        result = builder.output_config(
+            outdir, "parquet", "sample", "sample", "test_attr"
+        )
 
         assert isinstance(result, OutputConfig)
         assert result.outfile == outdir / "result.parquet"
@@ -230,6 +240,25 @@ class TestBuilder:
         result = builder._map_sex_to_id(["male", "F", "female", "M"])
 
         assert result == ["M", "F", "F", "M"]
+
+    def test_map_sex_to_id_maps_pato_ids(self, builder):
+        """test map_sex_to_id converts PATO IDs to M/F"""
+        result = builder._map_sex_to_id(["PATO:0000384", "PATO:0000383"])
+
+        assert result == ["M", "F"]
+
+    def test_map_sex_to_id_mixed_pato_and_string_input(self, builder):
+        """test map_sex_to_id handles a mix of PATO IDs, words, and codes"""
+        result = builder._map_sex_to_id(["PATO:0000384", "female", "M", "PATO:0000383"])
+
+        assert result == ["M", "F", "M", "F"]
+
+    def test_map_sex_to_id_logs_error_on_invalid_term(self, verbose_builder):
+        """test map_sex_to_id logs an error and skips invalid terms"""
+        result = verbose_builder._map_sex_to_id(["male", "invalid_term"])
+
+        assert result == ["M"]
+        verbose_builder.log.warning.assert_called_once()
 
     @patch("metahq_cli.retrieval_builder.check_filter_keys")
     def test_report_bad_filters_no_bad_filters(self, mock_check_keys, builder):
@@ -287,6 +316,21 @@ class TestBuilder:
         mock_check_txt.return_value = "male,female"
 
         result = builder.make_sex_curation("male,female", "direct")
+
+        assert isinstance(result, CurationConfig)
+        assert result.mode == "direct"
+        assert result.terms == ["M", "F"]
+        assert result.ontology == "sex"
+
+    @patch("metahq_cli.retrieval_builder.check_if_txt")
+    @patch("metahq_cli.retrieval_builder.check_mode")
+    def test_make_sex_curation_with_pato_ids(
+        self, mock_check_mode, mock_check_txt, builder
+    ):
+        """test make_sex_curation accepts PATO IDs as terms"""
+        mock_check_txt.return_value = "PATO:0000384,PATO:0000383"
+
+        result = builder.make_sex_curation("PATO:0000384,PATO:0000383", "direct")
 
         assert isinstance(result, CurationConfig)
         assert result.mode == "direct"


### PR DESCRIPTION
# What
Adds PATO:0000383 and PATO:0000384 as acceptable inputs for female and male, respectively.

# Why
* Offers an additional valid input for sex IDs
* Closes #89 

# How
* Included PATO to the valid inputs map in the `RetrievalBuilder._map_sex_ids` private method.

# PR Checklist
- [x] Explained the purpose of this PR
- [x] Added tests
- [x] Updated docs