### PR TITLE
feat(metadata): adds support for additional metadata fields

### DIFF
--- a/docs/user-guide/retrieve.md
+++ b/docs/user-guide/retrieve.md
@@ -30,7 +30,7 @@ All retrieve commands share the following common options:
     - `ecode`: Evidence code (e.g., `expert`, `crowd`, `any`)
     - `tech`: Technology type (e.g., `rnaseq`, `microarray`)
     - Combine multiple filters like so: `'species=human,ecode=expert,tech=rnaseq'`
-- `--license TEXT`: The license category of annotations (e.g, `any`, `permissive`, `nc`). Using `permissive` will retrieve annotations from sources with `CC0` and `CC BY` licenses. Using `nc` will retrieve sources with `CC BY-NC` or `Acedemic Only` licenses. Using `any` retrives annotations from any license. See our [citation documentation](../about/citation.md) for source license information. Default: `any`
+- `--license TEXT`: The license category of annotations (e.g, `any`, `permissive`, `nc`). Using `permissive` will retrieve annotations from sources with `CC0` and `CC BY` licenses. Using `nc` will retrieve sources with `CC BY-NC` or `Academic Only` licenses. Using `any` retrives annotations from any license. See our [citation documentation](../about/citation.md) for source license information. Default: `any`
 
 ### Output Options
 

--- a/packages/core/src/metahq_core/export/annotations.py
+++ b/packages/core/src/metahq_core/export/annotations.py
@@ -19,15 +19,8 @@ from metahq_core.export.base import BaseExporter
 from metahq_core.export.refinebio import RefineBioExporter
 from metahq_core.export.references import CitationConfig, save_citations
 from metahq_core.logger import setup_logger
-from metahq_core.util.io import checkdir, load_bson, save_json
-from metahq_core.util.supported import (
-    database_ids,
-    geo_metadata,
-    get_annotations,
-    get_default_log_dir,
-    metadata_fields,
-    supported,
-)
+from metahq_core.util.io import checkdir, save_json
+from metahq_core.util.supported import database_ids, get_default_log_dir
 
 if TYPE_CHECKING:
     import logging
@@ -276,103 +269,6 @@ class AnnotationsExporter(BaseExporter):
         """
         self._save_tabular("tsv", anno, file, citation_config, metadata, **kwargs)
 
-    def _get_descriptions(self, anno: Annotations):
-        """Collect descriptions to add the final output."""
-        representative = anno.ids.row(0, named=True)[anno.index_col]
-        if representative.startswith("GSM"):
-            level = "sample"
-        elif representative.startswith("GSE"):
-            level = "series"
-        else:
-            msg = "Congratulations! You broke the application. Please submit an issue."
-            if self.verbose:
-                self.log.error(msg)
-                self.log.debug(
-                    "%s was used to identify if the passed level is sample or series",
-                    representative,
-                )
-            raise RuntimeError(msg)
-
-        return (
-            pl.scan_parquet(geo_metadata(level))
-            .select([level, "description"])
-            .filter(pl.col(level).is_in(anno.index))
-            .rename({level: anno.index_col})
-            .collect()
-        )
-
-    def _get_save_method(self, fmt: str):
-        """Returns appropriate saving method."""
-        opt = {
-            "parquet": self._save_parquet,
-            "csv": self._save_csv,
-            "tsv": self._save_tsv,
-        }
-        if fmt in opt:
-            return opt[fmt]
-
-        msg = ("Expected fmt in %s, got %s.", list(opt.keys()), fmt)
-        if self.verbose:
-            self.log.error(msg)
-        raise ValueError(msg)
-
-    def _load_annotations(self, level: str) -> dict:
-        """Load the annotations dictionary for a given level."""
-        if level == "sample":
-            return load_bson(get_annotations("sample"))
-
-        if level == "series":
-            return load_bson(get_annotations("series"))
-
-        msg = ("Expected annotations level in %s, got %s.", supported("levels"), level)
-        if self.verbose:
-            self.log.error(msg)
-        raise ValueError(msg)
-
-    def _parse_metafields(self, index_col, fields: str) -> list[str]:
-        """Parse and check user-specified metadata fields."""
-        _metadata = fields.split(",")
-
-        flagged = False
-        for field in _metadata:
-            if field not in metadata_fields(index_col):
-                flagged = True
-                self.log.warning(
-                    "Requested metadata: %s, is not available. Skipping...", field
-                )
-
-        if flagged:
-            self.log.info("Run `metahq supported` to see available metadata fields.")
-
-        if not index_col in _metadata:
-            _metadata.append(index_col)
-        return _metadata
-
-    def _save_table_with_description(
-        self, file: FilePath, anno: Annotations, metadata: list[str], fmt: str, **kwargs
-    ):
-        """Fetches corresponding sample/study descriptions and saves the annotations
-        curation in tabular format (parquet, csv, tsv).
-        """
-
-        desc = self._get_descriptions(anno)
-        ids = [m for m in metadata if m != "description"]
-        reorder = metadata + anno.entities
-
-        df = (
-            anno.ids.select(ids)
-            .hstack(anno.data)  # stack IDs with annotations
-            .join(desc, on=anno.index_col, how="left")  # join with desc
-            .select(reorder)
-        )
-
-        save_method = self._get_save_method(fmt)
-        save_method(
-            df,
-            file,
-            **kwargs,
-        )
-
     def _save_tabular(
         self,
         fmt: str,
@@ -410,35 +306,13 @@ class AnnotationsExporter(BaseExporter):
         )
 
         self.log.info("Saving retrieval result to %s", Path(file).parent)
-        if "description" in _metadata:
-            self._save_table_with_description(file, anno, _metadata, fmt=fmt, **kwargs)
+        if self._geo_fields_in_metadata(_metadata, anno.index_col):
+            self._save_table_with_geo_metadata(file, anno, _metadata, fmt=fmt, **kwargs)
 
         else:
             self._get_save_method(fmt)(
                 anno.ids.select(_metadata).hstack(anno.data), file, **kwargs
             )
-
-    def _refinebio_in_metadata(self, metadata: list[str]) -> bool:
-        """Checks if any refine.bio IDs are in requested metadata."""
-        return len(list(set(metadata) & set(database_ids("refinebio")))) > 0
-
-    def _sra_in_metadata(self, metadata: list[str]) -> bool:
-        """Checks if any SRA IDs are in requested metadata."""
-        return len(list(set(metadata) & set(database_ids("sra")))) > 0
-
-    def _only_index(self, metadata: str | None, index: str):
-        """Check if no metadata passed or if only the index is passed."""
-        return (metadata is None) or (
-            isinstance(metadata, str) & (metadata.strip().replace(",", "") == index)
-        )
-
-    def _save_parquet(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to parquet."""
-        df.write_parquet(file, **kwargs)
-
-    def _save_csv(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to csv/tsv."""
-        df.write_csv(file, **kwargs, separator=",")
 
     def _save_json_only_index(self, anno: Annotations, file: FilePath):
         """Save annotations as JSON with only the index."""
@@ -485,9 +359,10 @@ class AnnotationsExporter(BaseExporter):
 
         stacked = anno.data.hstack(anno.ids)
 
-        if "description" in _metadata:
-            descs = self._get_descriptions(anno)
-            stacked = stacked.join(descs, on=anno.index_col, how="left").sort(
+        geo_fields = self._geo_fields_in_metadata(_metadata, anno.index_col)
+        if geo_fields:
+            geo = self._get_geo_metadata(anno, geo_fields)
+            stacked = stacked.join(geo, on=anno.index_col, how="left").sort(
                 anno.index_col
             )
 
@@ -501,10 +376,6 @@ class AnnotationsExporter(BaseExporter):
                 )
 
         save_json(_anno, file)
-
-    def _save_tsv(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to csv/tsv."""
-        df.write_csv(file, **kwargs, separator="\t")
 
     def _write_row(
         self, row: dict[str, str], anno: dict[str, list[str]], index_col: str

--- a/packages/core/src/metahq_core/export/base.py
+++ b/packages/core/src/metahq_core/export/base.py
@@ -4,7 +4,7 @@ Abstract base class for Curation export io classes.
 Author: Parker Hicks
 Date: 2025-09-08
 
-Last updated: 2025-09-08 by Parker Hicks
+Last updated: 2026-06-23 by Parker Hicks
 """
 
 from __future__ import annotations
@@ -12,14 +12,30 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+import polars as pl
 
+from metahq_core.util.io import load_bson
+from metahq_core.util.supported import (
+    database_ids,
+    geo_metadata,
+    geo_metadata_fields,
+    get_annotations,
+    metadata_fields,
+    supported,
+)
+
+if TYPE_CHECKING:
     from metahq_core.curations.base import BaseCuration
     from metahq_core.util.alltypes import FilePath, NpIntMatrix
 
 
 class BaseExporter(ABC):
-    """Base abstract class for Exporter children."""
+    """Base abstract class for Exporter children.
+
+    Concrete subclasses are expected to set ``self.log`` (a `logging.Logger`)
+    and ``self.verbose`` (bool) before any of the concrete helpers below are
+    used.
+    """
 
     @abstractmethod
     def to_json(
@@ -61,3 +77,122 @@ class BaseExporter(ABC):
         **kwargs,
     ):
         """Saves curation to tsv."""
+
+    def _load_annotations(self, level: str) -> dict:
+        """Load the annotations dictionary for a given level."""
+        if level == "sample":
+            return load_bson(get_annotations("sample"))
+
+        if level == "series":
+            return load_bson(get_annotations("series"))
+
+        msg = ("Expected annotations level in %s, got %s.", supported("levels"), level)
+        if self.verbose:
+            self.log.error(msg)
+        raise ValueError(msg)
+
+    def _parse_metafields(self, index_col: str, fields: str) -> list[str]:
+        """Parse and check user-specified metadata fields."""
+        _metadata = fields.split(",")
+
+        flagged = False
+        for field in _metadata:
+            if field not in metadata_fields(index_col):
+                flagged = True
+                self.log.warning(
+                    "Requested metadata: %s, is not available. Skipping...", field
+                )
+
+        if flagged:
+            self.log.info("Run `metahq supported` to see available metadata fields.")
+
+        if not index_col in _metadata:
+            _metadata.append(index_col)
+        return _metadata
+
+    def _refinebio_in_metadata(self, metadata: list[str]) -> bool:
+        """Checks if any refine.bio IDs are in requested metadata."""
+        return len(list(set(metadata) & set(database_ids("refinebio")))) > 0
+
+    def _sra_in_metadata(self, metadata: list[str]) -> bool:
+        """Checks if any SRA IDs are in requested metadata."""
+        return len(list(set(metadata) & set(database_ids("sra")))) > 0
+
+    def _geo_fields_in_metadata(self, metadata: list[str], index_col: str) -> list[str]:
+        """Returns the requested metadata fields that are sourced from the
+        GEO metadata parquet (e.g. description, title, summary, ...).
+        """
+        return [field for field in metadata if field in geo_metadata_fields(index_col)]
+
+    def _only_index(self, metadata: str | None, index: str) -> bool:
+        """Check if no metadata passed or if only the index is passed."""
+        return (metadata is None) or (
+            isinstance(metadata, str) & (metadata.strip().replace(",", "") == index)
+        )
+
+    def _get_geo_metadata(self, curation: BaseCuration, fields: list[str]) -> pl.DataFrame:
+        """Fetch requested GEO metadata fields (e.g. description, title,
+        summary, source_name_ch1, ...) for a curation's index.
+        """
+        level = curation.index_col
+        cols = self._geo_fields_in_metadata(fields, level)
+        return (
+            pl.scan_parquet(geo_metadata(level))
+            .select([level, *cols])
+            .filter(pl.col(level).is_in(curation.index))
+            .collect()
+        )
+
+    def _get_save_method(self, fmt: str):
+        """Returns appropriate saving method."""
+        opt = {
+            "parquet": self._save_parquet,
+            "csv": self._save_csv,
+            "tsv": self._save_tsv,
+        }
+        if fmt in opt:
+            return opt[fmt]
+
+        msg = ("Expected fmt in %s, got %s.", list(opt.keys()), fmt)
+        if self.verbose:
+            self.log.error(msg)
+        raise ValueError(msg)
+
+    def _save_table_with_geo_metadata(
+        self,
+        file: FilePath,
+        curation: BaseCuration,
+        metadata: list[str],
+        fmt: str,
+        **kwargs,
+    ):
+        """Fetches requested GEO metadata fields and saves the curation in
+        tabular format (parquet, csv, tsv).
+        """
+        geo_fields = self._geo_fields_in_metadata(metadata, curation.index_col)
+        geo = self._get_geo_metadata(curation, geo_fields)
+        ids = [field for field in metadata if field not in geo_fields]
+        reorder = metadata + curation.entities
+
+        df = (
+            curation.ids.select(ids)
+            .hstack(curation.data)
+            .join(geo, on=curation.index_col, how="left")
+            .select(reorder)
+            .sort(curation.index_col)
+        )
+
+        save_method = self._get_save_method(fmt)
+        save_method(df, file, **kwargs)
+
+    def _save_parquet(self, df: pl.DataFrame, file: FilePath, **kwargs):
+        """Save polars DataFrame to parquet."""
+        df.write_parquet(file, **kwargs)
+
+    def _save_csv(self, df: pl.DataFrame, file: FilePath, **kwargs):
+        """Save polars DataFrame to csv/tsv."""
+        df.write_csv(file, **kwargs, separator=",")
+
+    def _save_tsv(self, df: pl.DataFrame, file: FilePath, **kwargs):
+        """Save polars DataFrame to csv/tsv."""
+        df.write_csv(file, **kwargs, separator="\t")

--- a/packages/core/src/metahq_core/export/labels.py
+++ b/packages/core/src/metahq_core/export/labels.py
@@ -19,16 +19,8 @@ from metahq_core.export.base import BaseExporter
 from metahq_core.export.refinebio import RefineBioExporter
 from metahq_core.export.references import CitationConfig, save_citations
 from metahq_core.logger import setup_logger
-from metahq_core.util.io import checkdir, load_bson, save_json
-from metahq_core.util.supported import (
-    database_ids,
-    disease_ontologies,
-    geo_metadata,
-    get_annotations,
-    get_default_log_dir,
-    metadata_fields,
-    supported,
-)
+from metahq_core.util.io import checkdir, save_json
+from metahq_core.util.supported import database_ids, disease_ontologies, get_default_log_dir
 
 if TYPE_CHECKING:
     import logging
@@ -268,9 +260,10 @@ class LabelsExporter(BaseExporter):
 
             stacked = curation.data.hstack(curation.ids)
 
-            if "description" in _metadata:
-                descs = self._get_descriptions(curation)
-                stacked = stacked.join(descs, on=curation.index_col, how="left").sort(
+            geo_fields = self._geo_fields_in_metadata(_metadata, curation.index_col)
+            if geo_fields:
+                geo = self._get_geo_metadata(curation, geo_fields)
+                stacked = stacked.join(geo, on=curation.index_col, how="left").sort(
                     curation.index_col
                 )
 
@@ -338,103 +331,6 @@ class LabelsExporter(BaseExporter):
         """
         self._save_tabular("tsv", curation, file, citation_config, metadata, **kwargs)
 
-    def _get_descriptions(self, labels: Labels):
-        """Collect descriptions to add the final output."""
-        representative = labels.ids.row(0, named=True)[labels.index_col]
-        if representative.startswith("GSM"):
-            level = "sample"
-        elif representative.startswith("GSE"):
-            level = "series"
-        else:
-            msg = "Congratulations! You broke the application. Please submit an issue."
-            if self.verbose:
-                self.log.error(msg)
-                self.log.debug(
-                    "%s was used to identify if the passed level is sample or series",
-                    representative,
-                )
-            raise RuntimeError(msg)
-
-        return (
-            pl.scan_parquet(geo_metadata(level))
-            .select([level, "description"])
-            .filter(pl.col(level).is_in(labels.index))
-            .rename({level: labels.index_col})
-            .collect()
-        )
-
-    def _get_save_method(self, fmt: str):
-        """Returns appropriate saving method."""
-        opt = {
-            "parquet": self._save_parquet,
-            "csv": self._save_csv,
-            "tsv": self._save_tsv,
-        }
-        if fmt in opt:
-            return opt[fmt]
-
-        msg = ("Expected fmt in %s, got %s.", list(opt.keys()), fmt)
-        if self.verbose:
-            self.log.error(msg)
-        raise ValueError(msg)
-
-    def _load_annotations(self, level: str) -> dict:
-        """Load the annotations dictionary for a given level."""
-        if level == "sample":
-            return load_bson(get_annotations("sample"))
-
-        if level == "series":
-            return load_bson(get_annotations("series"))
-
-        msg = ("Expected annotations level in %s, got %s.", supported("levels"), level)
-        if self.verbose:
-            self.log.error(msg)
-        raise ValueError(msg)
-
-    def _parse_metafields(self, index_col, fields: str) -> list[str]:
-        """Parse and check user-specified metadata fields."""
-        _metadata = fields.split(",")
-
-        flagged = False
-        for field in _metadata:
-            if field not in metadata_fields(index_col):
-                flagged = True
-                self.log.warning(
-                    "Requested metadata: %s, is not available. Skipping...", field
-                )
-
-        if flagged:
-            self.log.info("Run `metahq supported` to see available metadata fields.")
-
-        if not index_col in _metadata:
-            _metadata.append(index_col)
-        return _metadata
-
-    def _save_table_with_description(
-        self, file: FilePath, labels: Labels, metadata: list[str], fmt: str, **kwargs
-    ):
-        """
-        Fetches corresponding sample/study descriptions and saves the labels
-        curation in tabular format (parquet, csv, tsv).
-        """
-
-        desc = self._get_descriptions(labels)
-        ids = [m for m in metadata if m != "description"]
-        reorder = metadata + labels.entities
-
-        save_method = self._get_save_method(fmt)
-        save_method(
-            (
-                labels.ids.select(ids)
-                .hstack(labels.data)  # stack IDs with labels
-                .join(desc, on=labels.index_col, how="left")  # join with desc
-                .select(reorder)
-                .sort(labels.index_col)
-            ),
-            file,
-            **kwargs,
-        )
-
     def _save_tabular(
         self,
         fmt: str,
@@ -472,8 +368,8 @@ class LabelsExporter(BaseExporter):
         )
 
         self.log.info("Saving retrieval result to %s", Path(file).parent)
-        if "description" in _metadata:
-            self._save_table_with_description(
+        if self._geo_fields_in_metadata(_metadata, curation.index_col):
+            self._save_table_with_geo_metadata(
                 file, curation, _metadata, fmt=fmt, **kwargs
             )
 
@@ -485,26 +381,6 @@ class LabelsExporter(BaseExporter):
                 file,
                 **kwargs,
             )
-
-    def _save_parquet(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to parquet."""
-        df.write_parquet(file, **kwargs)
-
-    def _save_csv(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to csv/tsv."""
-        df.write_csv(file, **kwargs, separator=",")
-
-    def _save_tsv(self, df: pl.DataFrame, file: FilePath, **kwargs):
-        """Save polars DataFrame to csv/tsv."""
-        df.write_csv(file, **kwargs, separator="\t")
-
-    def _refinebio_in_metadata(self, metadata: list[str]) -> bool:
-        """Checks if any refine.bio IDs are in requested metadata."""
-        return len(list(set(metadata) & set(database_ids("refinebio")))) > 0
-
-    def _sra_in_metadata(self, metadata: list[str]) -> bool:
-        """Checks if any SRA IDs are in requested metadata."""
-        return len(list(set(metadata) & set(database_ids("sra")))) > 0
 
     def _write_row(self, row: dict[str, str], labels: dict[str, dict], index_col: str):
         """Write a row of an Annotations curation to a dictionary."""

--- a/packages/core/src/metahq_core/util/supported.py
+++ b/packages/core/src/metahq_core/util/supported.py
@@ -104,6 +104,10 @@ def _sample_metadata() -> list[str]:
         "series",
         "platform",
         "description",
+        "source_name_ch1",
+        "characteristics_ch1",
+        "source_name_ch2",
+        "characteristics_ch2",
         "srx",
         "srs",
         "srp",
@@ -117,7 +121,11 @@ def _series_metadata() -> list[str]:
     return [
         "series",
         "platform",
+        "title",
+        "summary",
+        "overall_design",
         "description",
+        "sample_id",
         "srp",
         "refinebio_experiment",
     ]
@@ -368,6 +376,23 @@ def metadata_fields(level: str) -> list[str]:
         return _sample_metadata()
     if level == "series":
         return _series_metadata()
+    raise ValueError(f"Expected level in [sample, series], got {level}.")
+
+
+def geo_metadata_fields(level: str) -> list[str]:
+    """Returns metadata fields for a level that are sourced from the GEO
+    metadata parquet (as opposed to SRA or refine.bio ID mappings).
+    """
+    if level == "sample":
+        return [
+            "description",
+            "source_name_ch1",
+            "characteristics_ch1",
+            "source_name_ch2",
+            "characteristics_ch2",
+        ]
+    if level == "series":
+        return ["title", "summary", "overall_design", "description", "sample_id"]
     raise ValueError(f"Expected level in [sample, series], got {level}.")
 
 

--- a/packages/core/tests/test_metadata_fields.py
+++ b/packages/core/tests/test_metadata_fields.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for metadata field validation.
+
+Tests the new metadata fields added in the feat-metadata branch:
+- Sample metadata: source_name_ch1, characteristics_ch1, source_name_ch2, characteristics_ch2
+- Series metadata: title, summary, overall_design, sample_id
+
+Author: Parker Hicks
+Date: 2026-06-26
+
+Last updated: 2026-06-26 by Parker Hicks
+"""
+
+import pytest
+
+from metahq_core.util.supported import (
+    geo_metadata_fields,
+    metadata_fields,
+)
+
+
+class TestSampleMetadataFields:
+    """Test sample-level metadata fields."""
+
+    def test_sample_metadata_contains_required_fields(self):
+        """Test that sample metadata contains all required fields."""
+        sample_fields = metadata_fields("sample")
+
+        required_fields = [
+            "sample",
+            "series",
+            "platform",
+            "description",
+            "source_name_ch1",
+            "characteristics_ch1",
+            "source_name_ch2",
+            "characteristics_ch2",
+            "srx",
+            "srs",
+            "srp",
+            "refinebio_sample",
+            "refinebio_experiment",
+        ]
+
+        for field in required_fields:
+            assert field in sample_fields, f"Missing required field: {field}"
+
+    def test_sample_metadata_channel_fields_paired(self):
+        """Test that channel 1 and channel 2 fields exist for both source_name and characteristics."""
+        sample_meta = metadata_fields("sample")
+
+        # Verify both channels exist for source_name
+        assert "source_name_ch1" in sample_meta
+        assert "source_name_ch2" in sample_meta
+
+        # Verify both channels exist for characteristics
+        assert "characteristics_ch1" in sample_meta
+        assert "characteristics_ch2" in sample_meta
+
+    def test_sample_metadata_no_duplicates(self):
+        """Test that sample metadata has no duplicate fields."""
+        sample_meta = metadata_fields("sample")
+
+        # Check for duplicates
+        assert len(sample_meta) == len(
+            set(sample_meta)
+        ), "Sample metadata contains duplicate fields"
+
+
+class TestSeriesMetadataFields:
+    """Test series-level metadata fields."""
+
+    def test_series_metadata_contains_required_fields(self):
+        """Test that series metadata contains all required fields."""
+        series_fields = metadata_fields("series")
+
+        required_fields = [
+            "series",
+            "platform",
+            "title",
+            "summary",
+            "overall_design",
+            "description",
+            "sample_id",
+            "srp",
+            "refinebio_experiment",
+        ]
+
+        for field in required_fields:
+            assert field in series_fields, f"Missing required field: {field}"
+
+    def test_series_metadata_no_duplicates(self):
+        """Test that series metadata has no duplicate fields."""
+        series_meta = metadata_fields("series")
+
+        # Check for duplicates
+        assert len(series_meta) == len(
+            set(series_meta)
+        ), "Series metadata contains duplicate fields"
+
+
+class TestGeoMetadataFields:
+    """Test geo_metadata_fields function."""
+
+    def test_geo_metadata_sample_fields(self):
+        """Test that geo_metadata_fields returns correct sample-level fields."""
+        geo_sample_fields = geo_metadata_fields("sample")
+
+        expected_fields = [
+            "description",
+            "source_name_ch1",
+            "characteristics_ch1",
+            "source_name_ch2",
+            "characteristics_ch2",
+        ]
+
+        assert set(geo_sample_fields) == set(
+            expected_fields
+        ), f"Expected {expected_fields}, got {geo_sample_fields}"
+
+    def test_geo_metadata_series_fields(self):
+        """Test that geo_metadata_fields returns correct series-level fields."""
+        geo_series_fields = geo_metadata_fields("series")
+
+        expected_fields = [
+            "title",
+            "summary",
+            "overall_design",
+            "description",
+            "sample_id",
+        ]
+
+        assert set(geo_series_fields) == set(
+            expected_fields
+        ), f"Expected {expected_fields}, got {geo_series_fields}"
+
+    def test_geo_metadata_sample_excludes_sra_fields(self):
+        """Test that geo_metadata_fields for sample excludes SRA fields."""
+        geo_sample_fields = geo_metadata_fields("sample")
+
+        # SRA fields that should not be in GEO metadata
+        sra_fields = ["srx", "srs", "srp"]
+
+        for field in sra_fields:
+            assert (
+                field not in geo_sample_fields
+            ), f"SRA field {field} should not be in GEO metadata"
+
+    def test_geo_metadata_sample_excludes_refinebio_fields(self):
+        """Test that geo_metadata_fields for sample excludes refine.bio fields."""
+        geo_sample_fields = geo_metadata_fields("sample")
+
+        # refine.bio fields that should not be in GEO metadata
+        refinebio_fields = ["refinebio_sample", "refinebio_experiment"]
+
+        for field in refinebio_fields:
+            assert (
+                field not in geo_sample_fields
+            ), f"refine.bio field {field} should not be in GEO metadata"
+
+    def test_geo_metadata_series_excludes_sra_fields(self):
+        """Test that geo_metadata_fields for series excludes SRA fields."""
+        geo_series_fields = geo_metadata_fields("series")
+
+        # SRA fields that should not be in GEO metadata
+        assert (
+            "srp" not in geo_series_fields
+        ), "SRA field 'srp' should not be in GEO metadata"
+
+    def test_geo_metadata_series_excludes_refinebio_fields(self):
+        """Test that geo_metadata_fields for series excludes refine.bio fields."""
+        geo_series_fields = geo_metadata_fields("series")
+
+        # refine.bio fields that should not be in GEO metadata
+        assert (
+            "refinebio_experiment" not in geo_series_fields
+        ), "refine.bio field 'refinebio_experiment' should not be in GEO metadata"
+
+    def test_geo_metadata_invalid_level_raises_error(self):
+        """Test that geo_metadata_fields raises error for invalid level."""
+        with pytest.raises(ValueError, match="Expected level in"):
+            geo_metadata_fields("invalid_level")
+
+
+class TestMetadataFieldsFunction:
+    """Test metadata_fields function."""
+
+    def test_metadata_fields_sample_returns_list(self):
+        """Test that metadata_fields returns a list for sample level."""
+        result = metadata_fields("sample")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_metadata_fields_series_returns_list(self):
+        """Test that metadata_fields returns a list for series level."""
+        result = metadata_fields("series")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_metadata_fields_invalid_level_raises_error(self):
+        """Test that metadata_fields raises error for invalid level."""
+        with pytest.raises(ValueError, match="Expected level in"):
+            metadata_fields("invalid_level")
+
+
+class TestMetadataFieldsConsistency:
+    """Test consistency between metadata_fields and geo_metadata_fields."""
+
+    def test_geo_metadata_subset_of_all_metadata_sample(self):
+        """Test that GEO metadata fields are a subset of all metadata fields for sample."""
+        all_sample_meta = set(metadata_fields("sample"))
+        geo_sample_meta = set(geo_metadata_fields("sample"))
+
+        assert geo_sample_meta.issubset(
+            all_sample_meta
+        ), "GEO metadata fields should be a subset of all metadata fields"
+
+    def test_geo_metadata_subset_of_all_metadata_series(self):
+        """Test that GEO metadata fields are a subset of all metadata fields for series."""
+        all_series_meta = set(metadata_fields("series"))
+        geo_series_meta = set(geo_metadata_fields("series"))
+
+        assert geo_series_meta.issubset(
+            all_series_meta
+        ), "GEO metadata fields should be a subset of all metadata fields"
+
+    def test_sample_metadata_includes_id_fields(self):
+        """Test that sample metadata includes identifier fields."""
+        sample_meta = metadata_fields("sample")
+
+        id_fields = ["sample", "series", "platform"]
+        for field in id_fields:
+            assert field in sample_meta, f"Missing identifier field: {field}"
+
+    def test_series_metadata_includes_id_fields(self):
+        """Test that series metadata includes identifier fields."""
+        series_meta = metadata_fields("series")
+
+        id_fields = ["series", "platform"]
+        for field in id_fields:
+            assert field in series_meta, f"Missing identifier field: {field}"


### PR DESCRIPTION
# What
Includes additional supported metadata fields to query when executing `metahq retrieve`

# Why
I collected them from `OmicIDX` and they are already in the MetaHQ data package. They just needed to be added to the supported metadata fields in `metahq-core`.
* Closes #90

# How
* Added the additional fields to the `util/supported.py` module in `metahq-core`.
* Refactored the `export` modules in `metahq-core` to allow additional metadata columns when exporting.

# PR Checklist
- [x] Explained the purpose of this PR
- [x] Updated docs
  - docs point to `metahq supported` to find all relevant fields. 
- [x] Added tests (all passing)