### PR TITLE
Bug error handling

### DIFF
--- a/packages/cli/src/metahq_cli/retrieval_builder.py
+++ b/packages/cli/src/metahq_cli/retrieval_builder.py
@@ -7,6 +7,7 @@ Date: 2025-10-16
 Last updated: 2026-04-01 by Parker Hicks
 """
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -367,9 +368,6 @@ class Builder:
         """Check filters and return improper filter parameters."""
         bad_filters = check_filter_keys(filters)
         if len(bad_filters) > 0:
-            msg = ("Expected filters in %s, got %s.", required_filters(), bad_filters)
-
-            if self.verbose:
-                self.log.error(msg)
-
-            raise ValueError(msg)
+            msg = f"Expected filters in {required_filters()}. Got {bad_filters}."
+            self.log.error(msg)
+            sys.exit(1)

--- a/packages/cli/src/metahq_cli/retrieval_builder.py
+++ b/packages/cli/src/metahq_cli/retrieval_builder.py
@@ -4,7 +4,7 @@ Class to take retrieval arguments, check them, and build the retrieval query.
 Author: Parker Hicks
 Date: 2025-10-16
 
-Last updated: 2026-04-01 by Parker Hicks
+Last updated: 2026-06-29 by Parker Hicks
 """
 
 import sys

--- a/packages/cli/src/metahq_cli/retriever.py
+++ b/packages/cli/src/metahq_cli/retriever.py
@@ -9,6 +9,7 @@ Last updated: 2026-04-01 by Parker Hicks
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -160,7 +161,7 @@ class Retriever:
                 self.output_config,
             )
 
-    def curate(self, annotations: Annotations) -> Annotations:
+    def curate(self, annotations: Annotations) -> Annotations | Labels:
         """Mutate curations by specified mode.
 
         Arguments:
@@ -171,12 +172,10 @@ class Retriever:
             A populated Annotations or Labels object given the specified curation mode.
 
         Raises:
-            NoResultsFound: If there are no annotations for a set of query parameters.
+            Error: If there are no annotations for a set of query parameters.
         """
-        if annotations.n_indices == 0:
-            msg = "No annotations for any terms. Try using different conditions."
-            self.log.error(msg)
-            raise NoResultsFound(msg)
+        self._check_terms_available(annotations)
+        self._check_filters_results(annotations)
 
         if self.verbose:
             self.log.info("Curating...")
@@ -346,3 +345,23 @@ class Retriever:
             level=self.output_config.level,
             citation_config=self.citation_config,
         )
+
+    def _check_terms_available(self, annotations: Annotations) -> None:
+        not_available = []
+        for term in self.curation_config.terms:
+            if term not in annotations.entities:
+                not_available.append(term)
+
+        if len(not_available) == len(self.curation_config.terms):
+            self.log.error("No annotations available for your queried terms.")
+            sys.exit(1)
+
+    def _check_filters_results(self, annotations: Annotations) -> None:
+        """If terms are in MetaHQ, but there are no samples returned"""
+        if annotations.n_indices == 0:
+            msg = (
+                "No annotations for any terms given your filter parameters."
+                " Try using different filter values."
+            )
+            self.log.error(msg)
+            sys.exit(1)

--- a/packages/cli/tests/test_Builder.py
+++ b/packages/cli/tests/test_Builder.py
@@ -270,13 +270,26 @@ class TestBuilder:
         builder.report_bad_filters(filters)
 
     @patch("metahq_cli.retrieval_builder.check_filter_keys")
-    def test_report_bad_filters_raises_on_bad_filters(self, mock_check_keys, builder):
-        """test report_bad_filters raises ValueError for bad filters"""
+    def test_report_bad_filters_exits_on_bad_filters(self, mock_check_keys, builder):
+        """test report_bad_filters calls sys.exit for bad filters"""
         mock_check_keys.return_value = ["bad_filter"]
         filters = {"bad_filter": "value"}
 
-        with pytest.raises(ValueError):
+        with pytest.raises(SystemExit):
             builder.report_bad_filters(filters)
+
+    @patch("metahq_cli.retrieval_builder.check_filter_keys")
+    def test_report_bad_filters_logs_error_always(
+        self, mock_check_keys, builder
+    ):
+        """test report_bad_filters logs error regardless of verbose mode"""
+        mock_check_keys.return_value = ["bad_filter"]
+        filters = {"bad_filter": "value"}
+
+        with pytest.raises(SystemExit):
+            builder.report_bad_filters(filters)
+
+        builder.log.error.assert_called_once()
 
     @patch("metahq_cli.retrieval_builder.check_filter_keys")
     def test_report_bad_filters_logs_error_when_verbose(
@@ -286,7 +299,7 @@ class TestBuilder:
         mock_check_keys.return_value = ["bad_filter"]
         filters = {"bad_filter": "value"}
 
-        with pytest.raises(ValueError):
+        with pytest.raises(SystemExit):
             verbose_builder.report_bad_filters(filters)
 
         verbose_builder.log.error.assert_called_once()

--- a/packages/cli/tests/test_Retriever.py
+++ b/packages/cli/tests/test_Retriever.py
@@ -314,15 +314,26 @@ class TestRetriever:
         _, kwargs = mock_query_class.call_args
         assert kwargs["license"] == "permissive"
 
-    def test_curate_raises_error_when_no_annotations(self, retriever):
-        """test curate raises NoResultsFound when there are no annotations"""
+    def test_curate_exits_when_no_results_after_filters(self, retriever):
+        """test curate exits when terms exist in MetaHQ but filters return no results"""
         mock_annotations = Mock()
         mock_annotations.n_indices = 0
+        mock_annotations.entities = ["term1", "term2"]
 
-        with pytest.raises(NoResultsFound) as exc_info:
+        with pytest.raises(SystemExit):
             retriever.curate(mock_annotations)
 
-        assert "No annotations for any terms" in str(exc_info.value)
+        retriever.log.error.assert_called_once()
+
+    def test_curate_exits_when_all_terms_unavailable(self, retriever):
+        """test curate exits when none of the queried terms are in MetaHQ"""
+        mock_annotations = Mock()
+        mock_annotations.n_indices = 0
+        mock_annotations.entities = []
+
+        with pytest.raises(SystemExit):
+            retriever.curate(mock_annotations)
+
         retriever.log.error.assert_called_once()
 
     def test_curate_direct_mode(self, retriever):
@@ -345,6 +356,7 @@ class TestRetriever:
         """test curation with propagate mode"""
         mock_annotations = Mock()
         mock_annotations.n_indices = 10
+        mock_annotations.entities = ["term1", "term2"]
         retriever.curation_config.mode = "annotate"
 
         with patch.object(retriever, "_propagate_annotations") as mock_propagate:
@@ -358,6 +370,7 @@ class TestRetriever:
         """test curation with label mode"""
         mock_annotations = Mock()
         mock_annotations.n_indices = 10
+        mock_annotations.entities = ["term1", "term2"]
         retriever.curation_config.mode = "label"
 
         with patch.object(retriever, "_propagate_annotations") as mock_propagate:


### PR DESCRIPTION
# What
Error handling fixes in `Retriever` and `RetrievalBuilder`.

# Why
* Closes #79 
* Closes #93 

# How
* Adds graceful presentation of filters that were passed by the user for `metahq retrieve`, but are unrecognized by MetaHQ.
  * e.g. for `--filters "species=human,tech=rnaseq,ecode=expert,other=something"`, `other` will be highlighted as an unrecognized filter
  *  Added in `RetrievalBuilder`
* Adds error handling for queried terms that are not in MetaHQ.
  * Previously returned `polars.exceptions.NoDataError: unable to transpose an empty DataFrame`
  * Now gracefully states that no queried terms have annotations in MetaHQ. 

# PR Checklist
- [x] Explained the purpose of this PR
- [x] Updated tests (all passing)
- [x] Updated docs
  - Updated function docstrings