### PR TITLE
Fixes for platform and organism filtering during querying

### DIFF
--- a/packages/core/src/metahq_core/query.py
+++ b/packages/core/src/metahq_core/query.py
@@ -390,10 +390,11 @@ class UnParsedEntry:
         attr_exists = self.attribute in self.entry
         is_populated = len(self.entry) > 0
 
+        is_correct_species = False
         if "organism" in self.entry:
-            is_correct_species = self.entry["organism"] == self.species
-        else:
-            is_correct_species = False
+            if isinstance(self.entry["organism"], str):
+                if self.species in self.entry["organism"].split("|"):
+                    is_correct_species = True
 
         return attr_exists and is_populated and is_correct_species
 
@@ -562,7 +563,10 @@ class Query:
 
         parsed = parsed.to_polars()
         parsed = parsed.filter(
-            pl.col("platform").is_in(self._load_platforms())
+            pl.col("platform")
+            .str.split("|")
+            .list.eval(pl.element().is_in(self._load_platforms()))
+            .list.any()
         )  # filter platforms just once for speed
 
         if parsed.height == 0:

--- a/packages/core/tests/test_Query.py
+++ b/packages/core/tests/test_Query.py
@@ -4,10 +4,10 @@ Unit tests for Query class and related helper classes.
 Author: Parker Hicks
 Date: 2025-10-24
 
-Last updated: 2025-10-24 by Parker Hicks
+Last updated: 2026-07-09 by Parker Hicks
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import polars as pl
 import pytest
@@ -82,6 +82,34 @@ def sample_annotation_entry():
             "sample": "GSM123456",
             "series": "GSE12345",
             "platform": "GPL570",
+        },
+    }
+
+
+@pytest.fixture
+def series_annotation_entry():
+    """
+    Series annotation entry from the annotations dictionary with multiple
+    species and platforms
+    """
+    return {
+        "organism": "homo sapiens|mus musculus",
+        "tissue": {
+            "source1": {
+                "id": "UBERON:0001",
+                "value": "brain",
+                "ecode": "expert-curated",
+            },
+            "source2": {
+                "id": "UBERON:0002",
+                "value": "cerebral cortex",
+                "ecode": "expert-curated",
+            },
+        },
+        "accession_ids": {
+            "series": "GSE12345",
+            "platform": "GPL570",
+            "srp": "SRP1234",
         },
     }
 
@@ -464,6 +492,22 @@ class TestUnParsedEntry:
         assert "|" in ids
         assert "brain" in values
         assert "cerebral cortex" in values
+        assert "source1" in sources
+        assert "source2" in sources
+
+    def test_get_annotations_multiple_organisms(self, series_annotation_entry):
+        """Test getting annotations from series annotation with multiple organisms."""
+        entry = UnParsedEntry(
+            series_annotation_entry, "tissue", ["expert-curated"], "homo sapiens"
+        )
+        ids, values, sources = entry.get_annotations()
+
+        print(ids)
+        print(values)
+        print(sources)
+
+        assert "UBERON:0001" in ids
+        assert "brain" in values
         assert "source1" in sources
         assert "source2" in sources
 


### PR DESCRIPTION
# What
Fixes a bug where series with multiple organisms or platforms are filtered out during `metahq retrieve`

# Why
* Closes #88 

# How
* In the `query` module for `metahq_core`, converts species and platform checking to list-based evaluations.
  * Checks if the queried platform and/or species are in a list of platforms/species annotated to the MetaHQ entry split by a pipe delimiter.
  * Samples only have one platform or species so this does not affect existing behavior.


# PR Checklist
- [x] Explained the purpose of this PR
- [x] Updated tests (all tests passing)
- [x] Updated docs (NA)