### PR TITLE
Expand supported species

### DIFF
--- a/packages/core/src/metahq_core/util/supported.py
+++ b/packages/core/src/metahq_core/util/supported.py
@@ -166,6 +166,8 @@ def species_map() -> dict[str, str]:
         "mouse": "mus musculus",
         "zebrafish": "danio rerio",
         "rat": "rattus norvegicus",
+        "fly": "drosophila melanogaster",
+        "worm": "caenorhabditis elegans",
     }
 
 


### PR DESCRIPTION
# What
Adds fly (D. melanogaster) and worm (C. elegans) to the list of queriable species.

# Why
- Closes #92 

# How
Added common and scientific species names to `species_map` in the `metahq_core.util.supported` module.

# PR Checklist
- [x] Explained the purpose of this PR
- [x] Updated tests (NA)
- [x] Updated docs
  - All species in `species_map` are automatically displayed when running the `metahq supported` command