### PR TITLE
Zip database command and minor bug fixes

### DIFF
--- a/data/build_config.yaml
+++ b/data/build_config.yaml
@@ -72,7 +72,8 @@ processors:
 
 # -----------------------------------------------------------------
 # Per-stage settings
-# Stage names: process__<source>, combine__geo, combine__sra, combine__sample
+# Stage names: process__<source>, combine__geo, combine__sra, combine__sample,
+#              build__data_package, archive__data_package
 # Set skip: true to bypass a stage (useful with --start-from / --end-at too).
 # -----------------------------------------------------------------
 stages:
@@ -89,6 +90,9 @@ stages:
     skip: false
     use_checkpoint: true
   extract__mondo__relations:
+    skip: false
+    use_checkpoint: true
+  archive__data_package:
     skip: false
     use_checkpoint: true
 

--- a/packages/core/src/metahq_core/query.py
+++ b/packages/core/src/metahq_core/query.py
@@ -538,6 +538,11 @@ class Query:
             logger=self.log,
             verbose=self.verbose,
         )
+
+        # specify annotations are series-level if applicable
+        if self.level == "series":
+            result.collapsed = True
+
         return result
 
     def compile_annotations(self, id_cols: list[str]) -> pl.DataFrame:

--- a/packages/db_build/src/metahq_build/cli/main.py
+++ b/packages/db_build/src/metahq_build/cli/main.py
@@ -1006,6 +1006,111 @@ def refinebio_map(outfile, ids, sample_db, series_db, metadata_db):
     mapping.write_parquet(outfile)
 
 
+@main.command(name="zip-database")
+@click.option(
+    "--config",
+    "-c",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to configuration file",
+)
+@click.option(
+    "--package-dir",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to data package directory (overrides config)",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path),
+    help="Output archive path (default: <package_name>.tar.gz)",
+)
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    help="Enable verbose output",
+)
+def zip_database(config, package_dir, output, verbose):
+    """
+    Create a tar.gz archive of the MetaHQ database package.
+
+    Archives the complete data package into a compressed tar.gz file,
+    automatically filtering out platform-specific files (e.g., macOS ._ files).
+
+    Examples:
+
+        # Zip using config file
+        metahq-build zip-database --config data/build_config.yaml
+
+        # Zip specific directory
+        metahq-build zip-database --package-dir data/data_packages/metahq_data__v1.2.0
+
+        # Specify custom output path
+        metahq-build zip-database --config data/build_config.yaml -o my_archive.tar.gz
+    """
+    from metahq_build.util.archive import (
+        create_database_archive,
+        get_archive_path_from_package,
+    )
+
+    try:
+        # Determine package directory
+        if package_dir is None:
+            if config is None:
+                click.secho(
+                    "Error: Either --config or --package-dir is required",
+                    fg="red",
+                )
+                sys.exit(1)
+
+            pkg_config = DataPackageConfig.from_yaml(config)
+            package_dir = pkg_config.data_package_path
+
+        package_dir = Path(package_dir).resolve()
+
+        # Determine output path
+        if output is None:
+            output_path = get_archive_path_from_package(package_dir)
+        else:
+            output_path = Path(output).resolve()
+
+        # Check if output exists
+        if output_path.exists():
+            if not click.confirm(f"Output file {output_path} exists. Overwrite?"):
+                click.echo("Aborted.")
+                sys.exit(0)
+
+        click.echo(f"Creating archive: {output_path}")
+        click.echo(f"Source directory: {package_dir}")
+
+        # Create the archive with verbose callback
+        result = create_database_archive(
+            package_dir=package_dir,
+            output_path=output_path,
+            verbose=verbose,
+            verbose_callback=click.echo if verbose else None,
+        )
+
+        click.secho(
+            f"\n✓ Database successfully archived: {result['path']} ({result['size_mb']:.2f} MB)",
+            fg="green",
+        )
+
+    except FileNotFoundError as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        sys.exit(1)
+    except NotADirectoryError as e:
+        click.secho(f"Error: {e}", fg="red", err=True)
+        sys.exit(1)
+    except PermissionError as e:
+        click.secho(f"Error: Permission denied - {e}", fg="red", err=True)
+        sys.exit(1)
+    except Exception as e:
+        click.secho(f"Error: Failed to create archive", fg="red", err=True)
+        click.echo(f"{e}")
+        sys.exit(1)
+
+
 @main.command()
 @click.option(
     "--config",

--- a/packages/db_build/src/metahq_build/combiners/sra.py
+++ b/packages/db_build/src/metahq_build/combiners/sra.py
@@ -141,10 +141,11 @@ class SraCombiner(BaseAnnotationCombiner):
             len(xxr_ids),
             len(xxx_ids),
         )
-        mapping: pl.DataFrame = sra2gsm_map(xxr_ids, xxx_ids, db_path)
+        mapping: pl.DataFrame = sra2gsm_map(xxr_ids, xxx_ids, db_path).rename(
+            {"original_id": "sra", "gsm": "geo"}
+        )
         self.logger.info("Resolved %d IDs to GSM.", len(mapping))
 
-        # join mapping with manually assigned map
         mapping = pl.concat(
             [
                 mapping,
@@ -156,7 +157,7 @@ class SraCombiner(BaseAnnotationCombiner):
                 ),
             ],
             how="vertical",
-        )
+        ).unique()
 
         # Apply mapping and add each source.
         for source_name, data in source_data.items():

--- a/packages/db_build/src/metahq_build/ontology/relations.py
+++ b/packages/db_build/src/metahq_build/ontology/relations.py
@@ -177,14 +177,53 @@ class RelationsLazyFrame:
             (dict): A dictionary of the following structure:
                 {<group_by>: 'Term_x', <agg>: ['Term_a', 'Term_b', 'Term_c']}
         """
-        return (
-            lf.unpivot(index=ROW_ID, variable_name=COL_ID, value_name="value")
-            .filter(pl.col("value") != 0)
-            .group_by(group_by)
-            .agg(pl.col(agg))
-            .collect(engine=engine)
-            .to_dict(as_series=False)
-        )
+        # For very large matrices (>30k columns), unpivot can create billions of rows
+        # and hang even with streaming. Process in chunks to avoid memory issues.
+        schema = lf.collect_schema()
+        num_cols = len(schema) - 1  # subtract row_id column
+
+        if num_cols > 30000:
+            self.logger.info(
+                f"Large matrix detected ({num_cols} columns). Processing in chunks to avoid memory issues..."
+            )
+            chunk_size = 5000
+            all_results = []
+            col_names = [c for c in schema.names() if c != ROW_ID]
+
+            for i in range(0, len(col_names), chunk_size):
+                chunk_cols = col_names[i:i + chunk_size]
+                self.logger.debug(f"Processing chunk {i//chunk_size + 1}/{(len(col_names) + chunk_size - 1)//chunk_size}")
+
+                chunk_result = (
+                    lf.select([ROW_ID] + chunk_cols)
+                    .unpivot(index=ROW_ID, variable_name=COL_ID, value_name="value")
+                    .filter(pl.col("value") != 0)
+                    .group_by(group_by)
+                    .agg(pl.col(agg))
+                    .collect(engine="streaming")
+                )
+                all_results.append(chunk_result)
+
+            # Merge all chunks
+            combined = pl.concat(all_results)
+            # Re-group to merge lists from different chunks
+            final = (
+                combined
+                .explode(agg)
+                .group_by(group_by)
+                .agg(pl.col(agg))
+                .to_dict(as_series=False)
+            )
+            return final
+        else:
+            return (
+                lf.unpivot(index=ROW_ID, variable_name=COL_ID, value_name="value")
+                .filter(pl.col("value") != 0)
+                .group_by(group_by)
+                .agg(pl.col(agg))
+                .collect(engine=engine)
+                .to_dict(as_series=False)
+            )
 
     @staticmethod
     def _rm_self_relations(relations: dict[str, list[str]]) -> dict[str, list[str]]:

--- a/packages/db_build/src/metahq_build/pipeline/orchestrator.py
+++ b/packages/db_build/src/metahq_build/pipeline/orchestrator.py
@@ -233,5 +233,37 @@ class PipelineOrchestrator:
                 lambda: DataPackageBuilder(self.config).build(),
             )
         )
+        stages.append(
+            (
+                "archive__data_package",
+                lambda: self._archive_data_package(),
+            )
+        )
 
         return stages
+
+    def _archive_data_package(self) -> None:
+        """Create a compressed tar.gz archive of the data package."""
+        from metahq_build.util.archive import (
+            create_database_archive,
+            get_archive_path_from_package,
+        )
+
+        package_dir = self.config.data_package_path
+        archive_path = get_archive_path_from_package(package_dir)
+
+        self.logger.info("Creating archive: %s", archive_path)
+        self.logger.info("Source directory: %s", package_dir)
+
+        result = create_database_archive(
+            package_dir=package_dir,
+            output_path=archive_path,
+            verbose=self.config.verbose,
+            verbose_callback=self.logger.info if self.config.verbose else None,
+        )
+
+        self.logger.info(
+            "Database successfully archived: %s (%.2f MB)",
+            result['path'],
+            result['size_mb'],
+        )

--- a/packages/db_build/src/metahq_build/processors/gemma/processor.py
+++ b/packages/db_build/src/metahq_build/processors/gemma/processor.py
@@ -18,6 +18,7 @@ from metahq_build.config.config import (
     COL_ECODE,
     COL_TERM_ID,
     COL_TERM_NAME,
+    DISEASE_KEY,
     ECODE_EXPERT,
     GEMMA_DEV_STAGE_TO_AGE_GROUP,
     GEMMA_RAW,
@@ -26,8 +27,10 @@ from metahq_build.config.config import (
     PROCESSED_DIR,
     SEX_FEMALE_ID,
     SEX_MALE_ID,
+    TISSUE_KEY,
     UBERON_OBO,
     UBERON_SYSTEMS,
+    VALID_ONTOLOGIES,
 )
 from metahq_build.ontology import Ontology, get_system_descendants
 from metahq_build.processors.base import BaseProcessor, ProcessorError
@@ -189,6 +192,15 @@ class GemmaProcessor(BaseProcessor):
                 )
                 .with_columns(pl.coalesce(["mapped", COL_TERM_ID]).alias(COL_TERM_ID))
                 .drop("mapped")
+                .filter(
+                    ~(
+                        pl.col(COL_ATTRIBUTE).is_in([TISSUE_KEY, DISEASE_KEY])
+                        & ~pl.col(COL_TERM_ID)
+                        .str.split(":")
+                        .list.get(0)
+                        .is_in(list(VALID_ONTOLOGIES))
+                    )
+                )
             )
 
         self.logger.info("Parsed %d annotations from Gemma", len(df))

--- a/packages/db_build/src/metahq_build/util/__init__.py
+++ b/packages/db_build/src/metahq_build/util/__init__.py
@@ -1,11 +1,16 @@
 """
 Utility modules for metahq-build.
 
-Provides logging, progress tracking, and checkpointing utilities for
+Provides logging, progress tracking, checkpointing, and archiving utilities for
 long-running pipeline operations.
 """
 
 from metahq_build.util.age_groups import AGE_GROUPS, get_age_group
+from metahq_build.util.archive import (
+    create_database_archive,
+    get_archive_path_from_package,
+    should_exclude_file,
+)
 from metahq_build.util.checkpointing import (
     Checkpoint,
     CheckpointManager,
@@ -24,6 +29,10 @@ __all__ = [
     # Age groups
     "AGE_GROUPS",
     "get_age_group",
+    # Archive
+    "create_database_archive",
+    "get_archive_path_from_package",
+    "should_exclude_file",
     # Logging
     "setup_logger",
     "PipelineLogger",

--- a/packages/db_build/src/metahq_build/util/archive.py
+++ b/packages/db_build/src/metahq_build/util/archive.py
@@ -1,0 +1,152 @@
+"""
+Archive utilities for creating compressed database packages.
+
+Provides functionality to create tar.gz archives with cross-platform
+compatibility, filtering out platform-specific metadata files.
+"""
+
+import tarfile
+from pathlib import Path
+from typing import Callable, Optional
+
+
+def should_exclude_file(file_path: Path) -> tuple[bool, str]:
+    """
+    Determine if a file should be excluded from the archive.
+
+    Args:
+        file_path: Path to check
+
+    Returns:
+        Tuple of (should_exclude, reason)
+    """
+    name = file_path.name
+
+    # macOS resource fork files
+    if name.startswith("._"):
+        return True, "macOS resource fork"
+
+    # macOS metadata
+    if name == ".DS_Store":
+        return True, "macOS metadata"
+
+    # macOS extended attributes directory
+    if "__MACOSX" in str(file_path):
+        return True, "macOS metadata directory"
+
+    # Windows thumbnail cache
+    if name == "Thumbs.db":
+        return True, "Windows thumbnail cache"
+
+    # Windows folder settings
+    if name == "desktop.ini":
+        return True, "Windows folder settings"
+
+    # Temporary files
+    if name.endswith("~") or name.endswith(".tmp"):
+        return True, "temporary file"
+
+    # Hidden files (optional, but commonly excluded)
+    # Uncomment if you want to exclude all hidden files
+    # if name.startswith(".") and name not in {".gitkeep"}:
+    #     return True, "hidden file"
+
+    return False, ""
+
+
+def create_tar_filter(verbose_callback: Optional[Callable[[str], None]] = None):
+    """
+    Create a tarfile filter function that excludes unwanted files.
+
+    Args:
+        verbose_callback: Optional callback for logging excluded files
+
+    Returns:
+        Filter function for tarfile.add()
+    """
+
+    def tar_filter(tarinfo):
+        """Filter out platform-specific and temporary files."""
+        path = Path(tarinfo.name)
+        should_exclude, reason = should_exclude_file(path)
+
+        if should_exclude:
+            if verbose_callback:
+                verbose_callback(f"  Skipping: {tarinfo.name} ({reason})")
+            return None
+
+        return tarinfo
+
+    return tar_filter
+
+
+def create_database_archive(
+    package_dir: Path,
+    output_path: Path,
+    verbose: bool = False,
+    verbose_callback: Optional[Callable[[str], None]] = None,
+) -> dict:
+    """
+    Create a compressed tar.gz archive of a database package.
+
+    Args:
+        package_dir: Directory containing the database package
+        output_path: Path for the output archive file
+        verbose: Enable verbose output
+        verbose_callback: Optional callback for verbose messages
+
+    Returns:
+        Dictionary with archive metadata (path, size_bytes, size_mb)
+
+    Raises:
+        FileNotFoundError: If package_dir doesn't exist
+        NotADirectoryError: If package_dir is not a directory
+        PermissionError: If insufficient permissions
+        OSError: If archive creation fails
+    """
+    # Validate input
+    if not package_dir.exists():
+        raise FileNotFoundError(f"Package directory does not exist: {package_dir}")
+
+    if not package_dir.is_dir():
+        raise NotADirectoryError(f"Not a directory: {package_dir}")
+
+    # Create parent directory for output if needed
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create filter with optional callback
+    tar_filter = create_tar_filter(
+        verbose_callback=verbose_callback if verbose else None
+    )
+
+    # Create the tar.gz archive
+    with tarfile.open(output_path, "w:gz") as tar:
+        tar.add(
+            package_dir,
+            arcname=package_dir.name,
+            filter=tar_filter,
+        )
+
+    # Get file statistics
+    stat = output_path.stat()
+    size_bytes = stat.st_size
+    size_mb = size_bytes / (1024 * 1024)
+
+    return {
+        "path": output_path,
+        "size_bytes": size_bytes,
+        "size_mb": size_mb,
+    }
+
+
+def get_archive_path_from_package(package_dir: Path) -> Path:
+    """
+    Generate default archive path from package directory.
+
+    Args:
+        package_dir: Package directory path
+
+    Returns:
+        Archive path with .tar.gz extension
+    """
+    return package_dir.with_suffix(".tar.gz")


### PR DESCRIPTION
# What
- Adds module to zip the MetaHQ data package after building and an accompanying CLI command. 
- Fixes OOM error on Linux machines when building the ontology relations matrix for large ontology graphs.
- Removes annotations in Gemma that do not map to UBERON, MONDO, or CL.
- Fixes bug where series-level annotations were not marked as collapsed in `metahq_core.query`.

# Why
- Previously the data package zip was performed manually.
- The ontology OBO files were updated to the 2026 versions which added more terms and increased the size, so previously OOM issues were not present.
  -  Anecdotally, I have had this issue before using the polars streaming engine on linux machines where operations performed in-memory work correctly, but lazy operations fail.
  - This was a known issue in previous versions (pre v0.29.11): https://github.com/pola-rs/polars/issues/9943
- Previously, annotations from Gemma were mapped to UBERON, MONDO, and CL. However, any annotations that were not mapped were still included in the final output. I thought I fixed this before when I implemented the new cross-reference mapper, but could not find the commit.
  - When I merged that PR (#101), all tests for `metahq-build` passed which included checks for unsupported ontologies. I'm not yet sure what changed that caused those to fail here.
- There was a bug in the `annotations_converter` module where the converter attempted to vstack series-level labels with sample-level control annotations resulting in a `ColumnNotFound` error.

# PR Checklist
- [x] Explained the purpose of this PR
- [x] Updated tests (NA)
- [x] Updated docs (NA)