### PR TITLE
Refactor core export package

### DIFF
--- a/packages/core/src/metahq_core/export/annotations.py
+++ b/packages/core/src/metahq_core/export/annotations.py
@@ -29,9 +29,6 @@ if TYPE_CHECKING:
     from metahq_core.util.alltypes import FilePath, NpIntMatrix
 
 
-ANNOTATION_KEY = {"1": True, "0": False}
-
-
 class AnnotationsExporter(BaseExporter):
     """Exporter for Annotations curations.
 
@@ -314,16 +311,6 @@ class AnnotationsExporter(BaseExporter):
                 anno.ids.select(_metadata).hstack(anno.data), file, **kwargs
             )
 
-    def _save_json_only_index(self, anno: Annotations, file: FilePath):
-        """Save annotations as JSON with only the index."""
-        self.log.info("Saving retrieval result to %s", file)
-        _anno: dict[str, list[str]] = {}
-        stacked = anno.data.hstack(anno.ids)
-        for col in anno.entities:
-            _anno[col] = stacked.filter(pl.col(col) == 1)[anno.index_col].to_list()
-
-        save_json(_anno, file)
-
     def _save_json_with_metadata(
         self,
         anno: Annotations,
@@ -380,16 +367,6 @@ class AnnotationsExporter(BaseExporter):
                 )
 
         save_json(_anno, file)
-
-    def _write_row(
-        self, row: dict[str, str], anno: dict[str, list[str]], index_col: str
-    ):
-        """Write a row of an Annotations curation to a dictionary."""
-        idx = row[index_col]
-        for entity in anno:
-            _anno = str(row[entity])
-            if _anno in ANNOTATION_KEY:
-                anno[entity].append(idx)
 
     def _write_row_with_metadata(
         self,

--- a/packages/core/src/metahq_core/export/annotations.py
+++ b/packages/core/src/metahq_core/export/annotations.py
@@ -10,23 +10,20 @@ Last updated: 2026-04-13 by Parker Hicks
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import polars as pl
 
 from metahq_core.config import SOURCES_COL
 from metahq_core.export.base import BaseExporter
-from metahq_core.export.references import CitationConfig, save_citations
-from metahq_core.export.refinebio import RefineBioExporter
-from metahq_core.logger import setup_logger
-from metahq_core.util.io import checkdir, save_json
-from metahq_core.util.supported import database_ids, get_default_log_dir
+from metahq_core.export.references import save_citations
+from metahq_core.util.io import save_json
+from metahq_core.util.supported import database_ids
 
 if TYPE_CHECKING:
-    import logging
-
     from metahq_core.curations.annotations import Annotations
-    from metahq_core.util.alltypes import FilePath, NpIntMatrix
+    from metahq_core.export.references import CitationConfig
+    from metahq_core.util.alltypes import FilePath
 
 
 class AnnotationsExporter(BaseExporter):
@@ -52,135 +49,6 @@ class AnnotationsExporter(BaseExporter):
             Controls logging outputs.
 
     """
-
-    def __init__(
-        self,
-        attribute: str,
-        level: str,
-        logger=None,
-        loglevel=20,
-        logdir=get_default_log_dir(),
-        verbose=True,
-    ):
-        self.attribute = attribute
-        self._database = self._load_annotations(level)
-
-        if logger is None:
-            logger = setup_logger(__name__, level=loglevel, log_dir=logdir)
-        self.log: logging.Logger = logger
-        self.verbose: bool = verbose
-        self._refinebio = RefineBioExporter(logger=self.log, verbose=self.verbose)
-
-    def get_sra(self, anno: Annotations, fields: list[str]) -> Annotations:
-        """
-        Retrieve SRA IDs from the annotations if they exist.
-
-        Arguments:
-            anno (Annotations):
-                An Annotations curation containing samples and terms matching user-specified
-                filters.
-
-            fields (list[str]):
-                SRA ID levels (i.e., srr, srx, srs, or srp)
-
-        Returns:
-            A new Annotations curation with merged SRA IDs.
-
-        """
-        _anno = self._load_annotations(level=anno.index_col)  # all MetaHQ annotations
-
-        new_ids = {field: [] for field in fields}
-        new_ids[anno.index_col] = []
-        for idx in anno.index:
-            new_ids[anno.index_col].append(idx)
-
-            idx_accessions = _anno[idx]["accession_ids"]
-            for field in fields:
-                if field not in idx_accessions:
-                    new_ids[field].append("NA")
-                    continue
-
-                new_ids[field].append(idx_accessions[field])
-
-        return anno.add_ids(pl.DataFrame(new_ids))
-
-    def save(
-        self,
-        anno: Annotations,
-        fmt: Literal["json", "parquet", "csv", "tsv"],
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save annotations curation to json. Keys are terms and values are
-        positively annotated indices.
-
-        Arguments:
-            anno (Annotations):
-                A populated Annotations object.
-
-            fmt (Literal["json", "parquet", "csv", "tsv"]):
-                File format to save to.
-
-            file (FilePath):
-                Path to outfile.json.
-
-            citation_config (CitationConfig):
-                Parameters for saving citations.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        _ = checkdir(file, is_file=True)
-        opt = {
-            "json": self.to_json,
-            "parquet": self.to_parquet,
-            "csv": self.to_csv,
-            "tsv": self.to_tsv,
-        }
-
-        opt[fmt](anno, file, citation_config, metadata, **kwargs)
-
-        if self.verbose:
-            self.log.info("Saved!")
-
-    def to_refinebio_dataset(self, anno: Annotations) -> dict:
-        """Create a pre-populated refine.bio dataset from this curation's
-        samples and series, and submit it through refine.bio's dataset API.
-
-        Arguments:
-            anno (Annotations):
-                A populated Annotations curation.
-
-        Returns:
-            The JSON response from refine.bio's dataset API.
-        """
-        return self._refinebio.create_dataset(anno)
-
-    def to_csv(
-        self,
-        anno: Annotations,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save annotations to csv.
-
-        Arguments:
-            anno (Annotations):
-                A populated Annotations object.
-
-            file (FilePath):
-                Path to outfile.csv.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        self._save_tabular("csv", anno, file, citation_config, metadata, **kwargs)
 
     def to_json(
         self,
@@ -215,101 +83,6 @@ class AnnotationsExporter(BaseExporter):
             self.log.error(msg)
             self.log.debug("metadata dtype: %s", type(metadata))
             raise ValueError(msg)
-
-    def to_numpy(self, anno: Annotations) -> NpIntMatrix:
-        """Returns the annotation data as a numpy array."""
-        return anno.data.to_numpy()
-
-    def to_parquet(
-        self,
-        anno: Annotations,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save annotations to parquet.
-
-        Arguments:
-            anno (Annotations):
-                Annotations curation object to save.
-
-            file (FilePath):
-                Path to outfile.parquet.
-
-            metadata (str | None):
-                Metadata fields to include.
-
-        """
-        self._save_tabular("parquet", anno, file, citation_config, metadata, **kwargs)
-
-    def to_tsv(
-        self,
-        anno: Annotations,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save annotations to tsv.
-
-        Arguments:
-            anno (Annotations):
-                A populated Annotations object.
-
-            file (FilePath):
-                Path to outfile.tsv.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        self._save_tabular("tsv", anno, file, citation_config, metadata, **kwargs)
-
-    def _save_tabular(
-        self,
-        fmt: str,
-        anno: Annotations,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        if isinstance(metadata, str):
-            _metadata = self._parse_metafields(anno.index_col, metadata)
-
-        else:
-            _metadata = [anno.index_col]
-
-        if self._sra_in_metadata(_metadata):
-            anno = self.get_sra(
-                anno, [field for field in _metadata if field in database_ids("sra")]
-            )
-
-        if self._refinebio_in_metadata(_metadata):
-            anno = self._refinebio.get_refinebio(
-                anno,
-                [field for field in _metadata if field in database_ids("refinebio")],
-            )
-
-        _metadata.extend([SOURCES_COL])
-
-        # save sources to citation file
-        save_citations(
-            anno.ids[SOURCES_COL].str.split("|").explode().value_counts(sort=True),
-            citation_config,
-            logger=self.log,
-            verbose=self.verbose,
-        )
-
-        self.log.info("Saving retrieval result to %s", Path(file).parent)
-        if self._geo_fields_in_metadata(_metadata, anno.index_col):
-            self._save_table_with_geo_metadata(file, anno, _metadata, fmt=fmt, **kwargs)
-
-        else:
-            self._get_save_method(fmt)(
-                anno.ids.select(_metadata).hstack(anno.data), file, **kwargs
-            )
 
     def _save_json_with_metadata(
         self,

--- a/packages/core/src/metahq_core/export/annotations.py
+++ b/packages/core/src/metahq_core/export/annotations.py
@@ -211,7 +211,7 @@ class AnnotationsExporter(BaseExporter):
             self._save_json_with_metadata(anno, file, citation_config, metadata)
 
         else:
-            msg = ("Unexpected metedata arguments %s", metadata)
+            msg = f"Unexpected metadata argument: {metadata!r}"
             self.log.error(msg)
             self.log.debug("metadata dtype: %s", type(metadata))
             raise ValueError(msg)

--- a/packages/core/src/metahq_core/export/annotations.py
+++ b/packages/core/src/metahq_core/export/annotations.py
@@ -16,8 +16,8 @@ import polars as pl
 
 from metahq_core.config import SOURCES_COL
 from metahq_core.export.base import BaseExporter
-from metahq_core.export.refinebio import RefineBioExporter
 from metahq_core.export.references import CitationConfig, save_citations
+from metahq_core.export.refinebio import RefineBioExporter
 from metahq_core.logger import setup_logger
 from metahq_core.util.io import checkdir, save_json
 from metahq_core.util.supported import database_ids, get_default_log_dir
@@ -340,25 +340,29 @@ class AnnotationsExporter(BaseExporter):
         )
 
         self.log.info("Saving retrieval result to %s", Path(file).parent)
+
+        # initialize output dict
         _anno: dict[str, dict[str, dict[str, str]]] = {
             term: {} for term in anno.entities
         }
         _metadata = self._parse_metafields(anno.index_col, metadata)
         _metadata.extend(["sources"])
 
+        # append sra IDs if requested
         if self._sra_in_metadata(_metadata):
             anno = self.get_sra(
                 anno, [field for field in _metadata if field in database_ids("sra")]
             )
 
+        # append refine.bio IDs if requested
         if self._refinebio_in_metadata(_metadata):
             anno = self._refinebio.get_refinebio(
                 anno,
                 [field for field in _metadata if field in database_ids("refinebio")],
             )
 
+        # append requested GEO metadata fields
         stacked = anno.data.hstack(anno.ids)
-
         geo_fields = self._geo_fields_in_metadata(_metadata, anno.index_col)
         if geo_fields:
             geo = self._get_geo_metadata(anno, geo_fields)

--- a/packages/core/src/metahq_core/export/base.py
+++ b/packages/core/src/metahq_core/export/base.py
@@ -4,79 +4,255 @@ Abstract base class for Curation export io classes.
 Author: Parker Hicks
 Date: 2025-09-08
 
-Last updated: 2026-06-23 by Parker Hicks
+Last updated: 2026-08-10 by Parker Hicks
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 import polars as pl
 
-from metahq_core.util.io import load_bson
+from metahq_core.config import SOURCES_COL
+from metahq_core.export.references import save_citations
+from metahq_core.export.refinebio import RefineBioExporter
+from metahq_core.logger import setup_logger
+from metahq_core.util.io import checkdir, load_bson
 from metahq_core.util.supported import (
     database_ids,
     geo_metadata,
     geo_metadata_fields,
     get_annotations,
+    get_default_log_dir,
     metadata_fields,
     supported,
 )
 
 if TYPE_CHECKING:
+    import logging
+
     from metahq_core.curations.base import BaseCuration
+    from metahq_core.export.references import CitationConfig
     from metahq_core.util.alltypes import FilePath, NpIntMatrix
 
 
 class BaseExporter(ABC):
     """Base abstract class for Exporter children.
 
-    Concrete subclasses are expected to set ``self.log`` (a `logging.Logger`)
-    and ``self.verbose`` (bool) before any of the concrete helpers below are
-    used.
+    Attributes:
+        attribute (str):
+            Attribute of the annotations to save.
+
+        level (str):
+            Level of the annotations.
+
+        logger (logging.Logger):
+            Python builtin Logger.
+
+        loglevel (int):
+            Logging level.
+
+        logdir (str | Path):
+            Path to directory storing logs.
+
+        verbose (bool):
+            Controls logging outputs.
     """
+
+    def __init__(
+        self,
+        attribute: str,
+        level: str,
+        logger=None,
+        loglevel=20,
+        logdir=get_default_log_dir(),
+        verbose=True,
+    ):
+        self.attribute = attribute
+        self._database = self._load_annotations(level)
+
+        if logger is None:
+            logger = setup_logger(__name__, level=loglevel, log_dir=logdir)
+        self.log: logging.Logger = logger
+        self.verbose: bool = verbose
+        self._refinebio = RefineBioExporter(logger=self.log, verbose=self.verbose)
 
     @abstractmethod
     def to_json(
         self,
         curation: BaseCuration,
         file: FilePath,
-        metadata: str | None,
-        *args,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
         **kwargs,
     ):
         """Saves curation as json."""
 
-    @abstractmethod
     def to_numpy(self, curation: BaseCuration) -> NpIntMatrix:
-        """Returns curations matrix as numpy array."""
+        """Returns curation's data matrix as a numpy array."""
+        return curation.data.to_numpy()
 
-    @abstractmethod
     def to_parquet(
-        self, curation: BaseCuration, file: FilePath, metadata: str | None, **kwargs
+        self,
+        curation: BaseCuration,
+        file: FilePath,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
+        **kwargs,
     ):
-        """Saves curation to parquet."""
+        """Save curation to parquet.
 
-    @abstractmethod
+        Arguments:
+            curation (BaseCuration):
+                A populated curation object.
+
+            file (FilePath):
+                Path to outfile.parquet.
+
+            citation_config (CitationConfig):
+                Parameters for saving citations.
+
+            metadata (str | None):
+                Metadata fields to include.
+        """
+        self._save_tabular("parquet", curation, file, citation_config, metadata, **kwargs)
+
     def to_csv(
         self,
         curation: BaseCuration,
         file: FilePath,
-        metadata: str | None,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
         **kwargs,
     ):
-        """Saves curation to csv."""
+        """Save curation to csv.
 
-    @abstractmethod
+        Arguments:
+            curation (BaseCuration):
+                A populated curation object.
+
+            file (FilePath):
+                Path to outfile.csv.
+
+            citation_config (CitationConfig):
+                Parameters for saving citations.
+
+            metadata (str | None):
+                Metadata fields to include.
+        """
+        self._save_tabular("csv", curation, file, citation_config, metadata, **kwargs)
+
     def to_tsv(
         self,
         curation: BaseCuration,
         file: FilePath,
-        metadata: str | None,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
         **kwargs,
     ):
-        """Saves curation to tsv."""
+        """Save curation to tsv.
+
+        Arguments:
+            curation (BaseCuration):
+                A populated curation object.
+
+            file (FilePath):
+                Path to outfile.tsv.
+
+            citation_config (CitationConfig):
+                Parameters for saving citations.
+
+            metadata (str | None):
+                Metadata fields to include.
+        """
+        self._save_tabular("tsv", curation, file, citation_config, metadata, **kwargs)
+
+    def get_sra(self, curation: BaseCuration, fields: list[str]) -> BaseCuration:
+        """Retrieve SRA IDs from the MetaHQ annotations database if they exist.
+
+        Arguments:
+            curation (BaseCuration):
+                A curation containing samples or series matching user-specified
+                filters.
+
+            fields (list[str]):
+                SRA ID levels (i.e., srr, srx, srs, or srp).
+
+        Returns:
+            A new curation with merged SRA IDs.
+        """
+        _database = self._load_annotations(level=curation.index_col)
+
+        new_ids = {field: [] for field in fields}
+        new_ids[curation.index_col] = []
+        for idx in curation.index:
+            new_ids[curation.index_col].append(idx)
+
+            idx_accessions = _database[idx]["accession_ids"]
+            for field in fields:
+                if field not in idx_accessions:
+                    new_ids[field].append("NA")
+                    continue
+
+                new_ids[field].append(idx_accessions[field])
+
+        return curation.add_ids(pl.DataFrame(new_ids))
+
+    def save(
+        self,
+        curation: BaseCuration,
+        fmt: Literal["json", "parquet", "csv", "tsv"],
+        file: FilePath,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
+        **kwargs,
+    ):
+        """Save a curation to file.
+
+        Arguments:
+            curation (BaseCuration):
+                A populated curation object.
+
+            fmt (Literal["json", "parquet", "csv", "tsv"]):
+                File format to save to.
+
+            file (FilePath):
+                Path to outfile.
+
+            citation_config (CitationConfig):
+                Parameters for saving citations.
+
+            metadata (str | None):
+                Metadata fields to include.
+        """
+        _ = checkdir(file, is_file=True)
+        opt = {
+            "json": self.to_json,
+            "parquet": self.to_parquet,
+            "csv": self.to_csv,
+            "tsv": self.to_tsv,
+        }
+
+        opt[fmt](curation, file, citation_config, metadata, **kwargs)
+
+        if self.verbose:
+            self.log.info("Saved!")
+
+    def to_refinebio_dataset(self, curation: BaseCuration) -> dict:
+        """Create a pre-populated refine.bio dataset from this curation's
+        samples and series, and submit it through refine.bio's dataset API.
+
+        Arguments:
+            curation (BaseCuration):
+                A populated curation containing samples or series matching
+                user-specified filters.
+
+        Returns:
+            The JSON response from refine.bio's dataset API.
+        """
+        return self._refinebio.create_dataset(curation)
 
     def _load_annotations(self, level: str) -> dict:
         """Load the annotations dictionary for a given level."""
@@ -127,7 +303,7 @@ class BaseExporter(ABC):
     def _only_index(self, metadata: str | None, index: str) -> bool:
         """Check if no metadata passed or if only the index is passed."""
         return (metadata is None) or (
-            isinstance(metadata, str) & (metadata.strip().replace(",", "") == index)
+            isinstance(metadata, str) and (metadata.strip().replace(",", "") == index)
         )
 
     def _get_geo_metadata(self, curation: BaseCuration, fields: list[str]) -> pl.DataFrame:
@@ -157,6 +333,60 @@ class BaseExporter(ABC):
         if self.verbose:
             self.log.error(msg)
         raise ValueError(msg)
+
+    def _save_tabular(
+        self,
+        fmt: str,
+        curation: BaseCuration,
+        file: FilePath,
+        citation_config: CitationConfig,
+        metadata: str | None = None,
+        **kwargs,
+    ):
+        """Fetches SRA/refine.bio/GEO fields as requested and saves the
+        curation in tabular format (parquet, csv, tsv), sorted by index.
+        """
+        if isinstance(metadata, str):
+            _metadata = self._parse_metafields(curation.index_col, metadata)
+
+        else:
+            _metadata = [curation.index_col]
+
+        if self._sra_in_metadata(_metadata):
+            curation = self.get_sra(
+                curation, [field for field in _metadata if field in database_ids("sra")]
+            )
+
+        if self._refinebio_in_metadata(_metadata):
+            curation = self._refinebio.get_refinebio(
+                curation,
+                [field for field in _metadata if field in database_ids("refinebio")],
+            )
+
+        _metadata = _metadata + [SOURCES_COL]
+
+        # save sources to citation file
+        save_citations(
+            curation.ids[SOURCES_COL].str.split("|").explode().value_counts(sort=True),
+            citation_config,
+            logger=self.log,
+            verbose=self.verbose,
+        )
+
+        self.log.info("Saving retrieval result to %s", Path(file).parent)
+        if self._geo_fields_in_metadata(_metadata, curation.index_col):
+            self._save_table_with_geo_metadata(
+                file, curation, _metadata, fmt=fmt, **kwargs
+            )
+
+        else:
+            self._get_save_method(fmt)(
+                curation.ids.select(_metadata)
+                .hstack(curation.data)
+                .sort(curation.index_col),
+                file,
+                **kwargs,
+            )
 
     def _save_table_with_geo_metadata(
         self,

--- a/packages/core/src/metahq_core/export/base.py
+++ b/packages/core/src/metahq_core/export/base.py
@@ -86,7 +86,7 @@ class BaseExporter(ABC):
         if level == "series":
             return load_bson(get_annotations("series"))
 
-        msg = ("Expected annotations level in %s, got %s.", supported("levels"), level)
+        msg = f"Expected annotations level in {supported('levels')}, got {level}."
         if self.verbose:
             self.log.error(msg)
         raise ValueError(msg)
@@ -153,7 +153,7 @@ class BaseExporter(ABC):
         if fmt in opt:
             return opt[fmt]
 
-        msg = ("Expected fmt in %s, got %s.", list(opt.keys()), fmt)
+        msg = f"Expected fmt in {list(opt.keys())}, got {fmt}."
         if self.verbose:
             self.log.error(msg)
         raise ValueError(msg)

--- a/packages/core/src/metahq_core/export/labels.py
+++ b/packages/core/src/metahq_core/export/labels.py
@@ -272,7 +272,7 @@ class LabelsExporter(BaseExporter):
                     row, _labels, curation.index_col, _metadata
                 )
         else:
-            msg = ("Unexpected metedata arguments %s", metadata)
+            msg = f"Unexpected metadata argument: {metadata!r}"
             self.log.error(msg)
             self.log.debug("metadata dtype: %s", type(metadata))
             raise ValueError(msg)

--- a/packages/core/src/metahq_core/export/labels.py
+++ b/packages/core/src/metahq_core/export/labels.py
@@ -10,23 +10,18 @@ Last updated: 2026-04-13 by Parker Hicks
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
-
-import polars as pl
+from typing import TYPE_CHECKING
 
 from metahq_core.config import SOURCES_COL
 from metahq_core.export.base import BaseExporter
-from metahq_core.export.refinebio import RefineBioExporter
-from metahq_core.export.references import CitationConfig, save_citations
-from metahq_core.logger import setup_logger
-from metahq_core.util.io import checkdir, save_json
-from metahq_core.util.supported import database_ids, disease_ontologies, get_default_log_dir
+from metahq_core.export.references import save_citations
+from metahq_core.util.io import save_json
+from metahq_core.util.supported import database_ids, disease_ontologies
 
 if TYPE_CHECKING:
-    import logging
-
     from metahq_core.curations.labels import Labels
-    from metahq_core.util.alltypes import FilePath, NpIntMatrix
+    from metahq_core.export.references import CitationConfig
+    from metahq_core.util.alltypes import FilePath
 
 
 LABEL_KEY = {"1": "positive", "-1": "negative", "2": "control"}
@@ -56,136 +51,6 @@ class LabelsExporter(BaseExporter):
 
     """
 
-    def __init__(
-        self,
-        attribute: Literal["tissue", "disease", "sex", "age"],
-        level: Literal["sample", "series"],
-        logger=None,
-        loglevel=20,
-        logdir=get_default_log_dir(),
-        verbose=True,
-    ):
-        self.attribute = attribute
-        self._database = self._load_annotations(level)
-
-        if logger is None:
-            logger = setup_logger(__name__, level=loglevel, log_dir=logdir)
-        self.log: logging.Logger = logger
-        self.verbose: bool = verbose
-        self._refinebio = RefineBioExporter(logger=self.log, verbose=self.verbose)
-
-    def get_sra(self, labels: Labels, fields: list[str]) -> Labels:
-        """Retrieve SRA IDs from the annotations if they exist.
-
-        Arguments:
-            labels (Labels):
-                A Labels curation containing samples and terms matching user-specified
-                filters.
-
-            fields (list[str]):
-                SRA ID levels (i.e., srr, srx, srs, or srp)
-
-        Returns:
-            A new Annotations curation with merged SRA IDs.
-
-        """
-
-        _labels = self._load_annotations(
-            level=labels.index_col
-        )  # all MetaHQ annotations
-
-        new_ids = {field: [] for field in fields}
-        new_ids[labels.index_col] = []
-        for idx in labels.index:
-            new_ids[labels.index_col].append(idx)
-
-            idx_accessions = _labels[idx]["accession_ids"]
-            for field in fields:
-                if field not in idx_accessions:
-                    new_ids[field].append("NA")
-                    continue
-
-                new_ids[field].append(idx_accessions[field])
-
-        return labels.add_ids(pl.DataFrame(new_ids))
-
-    def save(
-        self,
-        labels: Labels,
-        fmt: Literal["json", "parquet", "csv", "tsv"],
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save labels curation to json. Keys are terms and values are
-        positively, negative, netral, and control labeled entries.
-
-        Arguments:
-            labels (Labels):
-                A populated Labels curation object.
-
-            fmt (Literal["json", "parquet", "csv", "tsv"]):
-                File format to save to.
-
-            file (FilePath):
-                Path to outfile.json.
-
-            citation_config (CitationConfig):
-                Parameters for saving citations.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        _ = checkdir(file, is_file=True)
-        opt = {
-            "json": self.to_json,
-            "parquet": self.to_parquet,
-            "csv": self.to_csv,
-            "tsv": self.to_tsv,
-        }
-        opt[fmt](labels, file, citation_config, metadata, **kwargs)
-
-        if self.verbose:
-            self.log.info("Saved!")
-
-    def to_refinebio_dataset(self, curation: Labels) -> dict:
-        """Create a pre-populated refine.bio dataset from this curation's
-        samples and series, and submit it through refine.bio's dataset API.
-
-        Arguments:
-            curation (Labels):
-                A populated Labels curation.
-
-        Returns:
-            The JSON response from refine.bio's dataset API.
-        """
-        return self._refinebio.create_dataset(curation)
-
-    def to_csv(
-        self,
-        curation: Labels,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save labels to csv.
-
-        Arguments:
-            curation (Labels):
-                A populated Labels curation object.
-
-            file (FilePath):
-                Path to outfile.csv.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        self._save_tabular("csv", curation, file, citation_config, metadata, **kwargs)
-
     def to_json(
         self,
         curation: Labels,
@@ -194,7 +59,8 @@ class LabelsExporter(BaseExporter):
         metadata: str | None = None,
     ):
         """Save labels curation to json. Keys are terms and values are
-        positively labelstated indices.
+        positive, negative, and (for disease ontology terms) control labeled
+        entries.
 
         Arguments:
             curation (Labels):
@@ -221,10 +87,7 @@ class LabelsExporter(BaseExporter):
                 term: {"positive": [], "negative": []} for term in curation.entities
             }
 
-        if (metadata is None) or (
-            isinstance(metadata, str)
-            & (metadata.strip().replace(",", "") == curation.index_col)
-        ):
+        if self._only_index(metadata, curation.index_col):
             metadata = curation.index_col
 
         if isinstance(metadata, str):
@@ -279,109 +142,6 @@ class LabelsExporter(BaseExporter):
 
         save_json(_labels, file)
 
-    def to_numpy(self, curation: Labels) -> NpIntMatrix:
-        """Returns the labelstation data as a numpy array."""
-        return curation.data.to_numpy()
-
-    def to_parquet(
-        self,
-        curation: Labels,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save labels to parquet.
-
-        Arguments:
-            curation (Labels):
-                Labels curation object to save.
-
-            file (FilePath):
-                Path to outfile.parquet.
-
-            metadata (str | None):
-                Metadata fields to include.
-
-        """
-        self._save_tabular(
-            "parquet", curation, file, citation_config, metadata, **kwargs
-        )
-
-    def to_tsv(
-        self,
-        curation: Labels,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        """Save labels to tsv.
-
-        Arguments:
-            curation (Labels):
-                A populated Labels curation object.
-
-            file (FilePath):
-                Path to outfile.tsv.
-
-            metadata (str):
-                Metadata fields to include.
-
-        """
-        self._save_tabular("tsv", curation, file, citation_config, metadata, **kwargs)
-
-    def _save_tabular(
-        self,
-        fmt: str,
-        curation: Labels,
-        file: FilePath,
-        citation_config: CitationConfig,
-        metadata: str | None = None,
-        **kwargs,
-    ):
-        if isinstance(metadata, str):
-            _metadata = self._parse_metafields(curation.index_col, metadata)
-
-        else:
-            _metadata = [curation.index_col]
-
-        if self._sra_in_metadata(_metadata):
-            curation = self.get_sra(
-                curation, [field for field in _metadata if field in database_ids("sra")]
-            )
-
-        if self._refinebio_in_metadata(_metadata):
-            curation = self._refinebio.get_refinebio(
-                curation,
-                [field for field in _metadata if field in database_ids("refinebio")],
-            )
-
-        _metadata = _metadata + [SOURCES_COL]
-
-        # save sources to citation file
-        save_citations(
-            curation.ids[SOURCES_COL].str.split("|").explode().value_counts(sort=True),
-            citation_config,
-            logger=self.log,
-            verbose=self.verbose,
-        )
-
-        self.log.info("Saving retrieval result to %s", Path(file).parent)
-        if self._geo_fields_in_metadata(_metadata, curation.index_col):
-            self._save_table_with_geo_metadata(
-                file, curation, _metadata, fmt=fmt, **kwargs
-            )
-
-        else:
-            self._get_save_method(fmt)(
-                curation.ids.select(_metadata)
-                .hstack(curation.data)
-                .sort(curation.index_col),
-                file,
-                **kwargs,
-            )
-
     def _write_row_with_metadata(
         self,
         row: dict[str, str],
@@ -389,7 +149,7 @@ class LabelsExporter(BaseExporter):
         index_col: str,
         metadata: list[str],
     ):
-        """Write a row of an Annotations curation to a dictionary with metadata."""
+        """Write a row of a Labels curation to a dictionary with metadata."""
         idx = row[index_col]
         for entity in labels:
             label = str(row[entity])

--- a/packages/core/src/metahq_core/export/labels.py
+++ b/packages/core/src/metahq_core/export/labels.py
@@ -382,14 +382,6 @@ class LabelsExporter(BaseExporter):
                 **kwargs,
             )
 
-    def _write_row(self, row: dict[str, str], labels: dict[str, dict], index_col: str):
-        """Write a row of an Annotations curation to a dictionary."""
-        idx = row[index_col]
-        for entity in labels:
-            label = str(row[entity])
-            if label in LABEL_KEY:
-                labels[entity][LABEL_KEY[label]].append(idx)
-
     def _write_row_with_metadata(
         self,
         row: dict[str, str],

--- a/packages/core/src/metahq_core/export/references.py
+++ b/packages/core/src/metahq_core/export/references.py
@@ -195,11 +195,10 @@ def format_reference(reference: Reference, index: int, indent: str = "    ") -> 
 
 def format_references(references: list[Reference]) -> str:
     """
-    Format a list of (reference, annotation_count) tuples.
+    Format a list of references.
 
     Arguments:
-        references (list[tuple[Reference, int]]): List of tuples
-            containing (Reference, annotation_count).
+        references (list[Reference]): List of populated Reference objects.
 
     Returns:
         (str): Formatted string with all references numbered sequentially.

--- a/packages/core/src/metahq_core/export/refinebio.py
+++ b/packages/core/src/metahq_core/export/refinebio.py
@@ -150,11 +150,7 @@ class RefineBioExporter:
         if index_col in GEO_COL_BY_INDEX:
             return GEO_COL_BY_INDEX[index_col]
 
-        msg = (
-            "Expected curation index_col in %s, got %s.",
-            list(GEO_COL_BY_INDEX),
-            index_col,
-        )
+        msg = f"Expected curation index_col in {list(GEO_COL_BY_INDEX)}, got {index_col}."
         if self.verbose:
             self.log.error(msg)
         raise ValueError(msg)

--- a/packages/core/tests/test_AnnotationsExporter.py
+++ b/packages/core/tests/test_AnnotationsExporter.py
@@ -1,0 +1,141 @@
+"""
+Unit tests for AnnotationsExporter.to_json and its private helpers - the
+logic that stays specific to AnnotationsExporter after the shared save/csv/
+parquet/tsv/get_sra behavior is consolidated onto BaseExporter.
+
+Author: Parker Hicks
+Date: 2026-08-10
+"""
+
+import json
+from unittest.mock import Mock
+
+import polars as pl
+import pytest
+
+from metahq_core.curations.annotations import Annotations
+from metahq_core.export.annotations import AnnotationsExporter
+from metahq_core.export.references import CitationConfig
+
+ANNOTATIONS_DB = {
+    "GSM1": {"accession_ids": {"srr": "SRR1"}},
+    "GSM2": {"accession_ids": {"srr": "SRR2"}},
+    "GSM3": {"accession_ids": {}},
+    "GSM4": {"accession_ids": {"srr": "SRR4"}},
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_annotations_db(monkeypatch):
+    monkeypatch.setattr(
+        "metahq_core.export.base.load_bson", lambda *a, **k: ANNOTATIONS_DB
+    )
+
+
+@pytest.fixture
+def sample_annotations():
+    data = pl.DataFrame({"UBERON:0000948": [1, 0, 1, 0]})
+    ids = pl.DataFrame(
+        {
+            "sample": ["GSM1", "GSM2", "GSM3", "GSM4"],
+            "series": ["GSE1", "GSE1", "GSE2", "GSE1"],
+            "sources": ["KrishnanLab", "KrishnanLab", "KrishnanLab", "KrishnanLab"],
+        }
+    )
+    return Annotations(data, ids, index_col="sample", group_cols=("series", "sources"))
+
+
+@pytest.fixture
+def anno_exporter():
+    return AnnotationsExporter(
+        attribute="tissue", level="sample", logger=Mock(), verbose=False
+    )
+
+
+@pytest.fixture
+def citation_config(tmp_path):
+    return CitationConfig(
+        version="1.0.0",
+        terms="tissue",
+        attribute="tissue",
+        level="sample",
+        species="human",
+        ecode="expert",
+        tech="rna-seq",
+        mode="annotate",
+        license="all",
+        date="2026-08-10 00:00:00",
+        outfile=tmp_path / "CITATION.txt",
+    )
+
+
+class TestToJson:
+    """test to_json happy paths and error path"""
+
+    def test_no_metadata_includes_only_index_entries(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        anno_exporter.to_json(sample_annotations, outfile, citation_config, metadata=None)
+
+        result = json.loads(outfile.read_text())
+        assert set(result["UBERON:0000948"].keys()) == {"GSM1", "GSM3"}
+
+    def test_with_metadata_attaches_requested_fields(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        anno_exporter.to_json(
+            sample_annotations, outfile, citation_config, metadata="sample,srr"
+        )
+
+        result = json.loads(outfile.read_text())
+        assert result["UBERON:0000948"]["GSM1"]["srr"] == "SRR1"
+
+    def test_merges_refinebio_fields_when_requested(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        anno_exporter._refinebio._map = pl.DataFrame(
+            {
+                "gsm": ["GSM1", "GSM2", "GSM3", "GSM4"],
+                "gse": ["GSE1", "GSE1", "GSE2", "GSE1"],
+                "refinebio_sample": ["RB1", "RB2", "RB3", "RB4"],
+                "refinebio_experiment": ["RBE1", "RBE1", "RBE2", "RBE1"],
+            }
+        )
+        outfile = tmp_path / "out.json"
+        anno_exporter.to_json(
+            sample_annotations,
+            outfile,
+            citation_config,
+            metadata="sample,refinebio_sample",
+        )
+
+        result = json.loads(outfile.read_text())
+        assert result["UBERON:0000948"]["GSM1"]["refinebio_sample"] == "RB1"
+
+    def test_only_index_and_string_metadata_produce_same_shape(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        no_metadata = tmp_path / "no_metadata.json"
+        anno_exporter.to_json(
+            sample_annotations, no_metadata, citation_config, metadata=None
+        )
+
+        explicit_index = tmp_path / "explicit_index.json"
+        anno_exporter.to_json(
+            sample_annotations, explicit_index, citation_config, metadata="sample"
+        )
+
+        assert json.loads(no_metadata.read_text()) == json.loads(
+            explicit_index.read_text()
+        )
+
+    def test_non_str_non_none_metadata_raises_readable_valueerror(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        with pytest.raises(ValueError, match=r"Unexpected metadata argument: 123") as exc:
+            anno_exporter.to_json(sample_annotations, outfile, citation_config, metadata=123)
+
+        assert isinstance(exc.value.args[0], str)

--- a/packages/core/tests/test_BaseExporter.py
+++ b/packages/core/tests/test_BaseExporter.py
@@ -1,0 +1,284 @@
+"""
+Unit tests for exporter behavior shared between AnnotationsExporter and
+LabelsExporter. BaseExporter cannot be instantiated directly (to_json stays
+abstract), so these tests exercise the shared behavior through the concrete
+subclasses.
+
+Author: Parker Hicks
+Date: 2026-08-10
+"""
+
+from unittest.mock import Mock, patch
+
+import polars as pl
+import pytest
+
+from metahq_core.curations.annotations import Annotations
+from metahq_core.curations.labels import Labels
+from metahq_core.export.annotations import AnnotationsExporter
+from metahq_core.export.labels import LabelsExporter
+from metahq_core.export.references import CitationConfig
+
+ANNOTATIONS_DB = {
+    "GSM1": {"accession_ids": {"srr": "SRR1", "srx": "SRX1"}},
+    "GSM2": {"accession_ids": {"srr": "SRR2"}},
+    "GSM3": {"accession_ids": {}},
+    "GSM4": {"accession_ids": {"srr": "SRR4"}},
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_annotations_db(monkeypatch):
+    """Stub the bson annotations-database filesystem read used by
+    BaseExporter._load_annotations (called from __init__ and get_sra)."""
+    monkeypatch.setattr(
+        "metahq_core.export.base.load_bson", lambda *a, **k: ANNOTATIONS_DB
+    )
+
+
+@pytest.fixture
+def mock_logger():
+    return Mock()
+
+
+@pytest.fixture
+def sample_annotations():
+    """sample-level annotations curation, index unsorted on purpose so the
+    tabular save-order behavior is actually exercised."""
+    data = pl.DataFrame({"UBERON:0000948": [0, 1, 1, 0]})
+    ids = pl.DataFrame(
+        {
+            "sample": ["GSM3", "GSM1", "GSM4", "GSM2"],
+            "series": ["GSE2", "GSE1", "GSE1", "GSE1"],
+            "sources": ["KrishnanLab", "KrishnanLab", "KrishnanLab", "KrishnanLab"],
+        }
+    )
+    return Annotations(data, ids, index_col="sample", group_cols=("series", "sources"))
+
+
+@pytest.fixture
+def sample_labels():
+    data = pl.DataFrame({"UBERON:0000948": [1, -1, 1, 0]})
+    ids = pl.DataFrame(
+        {
+            "sample": ["GSM3", "GSM1", "GSM4", "GSM2"],
+            "series": ["GSE2", "GSE1", "GSE1", "GSE1"],
+            "sources": ["KrishnanLab", "KrishnanLab", "KrishnanLab", "KrishnanLab"],
+        }
+    )
+    return Labels(data, ids, index_col="sample", group_cols=("series", "sources"))
+
+
+@pytest.fixture
+def anno_exporter(mock_logger):
+    exp = AnnotationsExporter(
+        attribute="tissue", level="sample", logger=mock_logger, verbose=True
+    )
+    exp._refinebio._map = pl.DataFrame(
+        {
+            "gsm": ["GSM1", "GSM2", "GSM3", "GSM4"],
+            "gse": ["GSE1", "GSE1", "GSE2", "GSE1"],
+            "refinebio_sample": ["RB_GSM1", "RB_GSM2", "RB_GSM3", "RB_GSM4"],
+            "refinebio_experiment": ["RB_GSE1", "RB_GSE1", "RB_GSE2", "RB_GSE1"],
+        }
+    )
+    return exp
+
+
+@pytest.fixture
+def labels_exporter(mock_logger):
+    exp = LabelsExporter(
+        attribute="tissue", level="sample", logger=mock_logger, verbose=True
+    )
+    exp._refinebio._map = pl.DataFrame(
+        {
+            "gsm": ["GSM1", "GSM2", "GSM3", "GSM4"],
+            "gse": ["GSE1", "GSE1", "GSE2", "GSE1"],
+            "refinebio_sample": ["RB_GSM1", "RB_GSM2", "RB_GSM3", "RB_GSM4"],
+            "refinebio_experiment": ["RB_GSE1", "RB_GSE1", "RB_GSE2", "RB_GSE1"],
+        }
+    )
+    return exp
+
+
+@pytest.fixture
+def citation_config(tmp_path):
+    return CitationConfig(
+        version="1.0.0",
+        terms="tissue",
+        attribute="tissue",
+        level="sample",
+        species="human",
+        ecode="expert",
+        tech="rna-seq",
+        mode="annotate",
+        license="all",
+        date="2026-08-10 00:00:00",
+        outfile=tmp_path / "CITATION.txt",
+    )
+
+
+class TestGetSra:
+    """test get_sra, shared identically between both exporters"""
+
+    def test_merges_sra_ids_for_annotations(self, anno_exporter, sample_annotations):
+        merged = anno_exporter.get_sra(sample_annotations, ["srr", "srx"])
+
+        assert isinstance(merged, Annotations)
+        by_sample = dict(zip(merged.ids["sample"].to_list(), merged.ids["srr"].to_list()))
+        assert by_sample["GSM1"] == "SRR1"
+        assert by_sample["GSM3"] == "NA"
+
+    def test_missing_field_filled_with_na(self, anno_exporter, sample_annotations):
+        merged = anno_exporter.get_sra(sample_annotations, ["srx"])
+        by_sample = dict(zip(merged.ids["sample"].to_list(), merged.ids["srx"].to_list()))
+        assert by_sample["GSM2"] == "NA"
+
+    def test_preserves_index_order(self, anno_exporter, sample_annotations):
+        merged = anno_exporter.get_sra(sample_annotations, ["srr"])
+        assert merged.index == sample_annotations.index
+
+    def test_works_for_labels_curation(self, labels_exporter, sample_labels):
+        merged = labels_exporter.get_sra(sample_labels, ["srr"])
+        assert isinstance(merged, Labels)
+        assert merged.ids["srr"].to_list() == ["NA", "SRR1", "SRR4", "SRR2"]
+
+
+class TestSave:
+    """test save, shared identically between both exporters"""
+
+    def test_dispatches_to_to_csv(self, anno_exporter, sample_annotations, tmp_path):
+        outfile = tmp_path / "out.csv"
+        with patch.object(anno_exporter, "to_csv") as mock_to_csv:
+            anno_exporter.save(sample_annotations, "csv", outfile, Mock())
+        mock_to_csv.assert_called_once()
+
+    def test_logs_saved_when_verbose(
+        self, anno_exporter, sample_annotations, tmp_path, mock_logger
+    ):
+        outfile = tmp_path / "out.csv"
+        with patch.object(anno_exporter, "to_csv"):
+            anno_exporter.save(sample_annotations, "csv", outfile, Mock())
+        mock_logger.info.assert_any_call("Saved!")
+
+    def test_silent_when_not_verbose(self, mock_logger, sample_annotations, tmp_path):
+        exp = AnnotationsExporter(
+            attribute="tissue", level="sample", logger=mock_logger, verbose=False
+        )
+        outfile = tmp_path / "out.csv"
+        with patch.object(exp, "to_csv"):
+            exp.save(sample_annotations, "csv", outfile, Mock())
+        assert "Saved!" not in [c.args[0] for c in mock_logger.info.call_args_list]
+
+    def test_creates_parent_directory(self, anno_exporter, sample_annotations, tmp_path):
+        outfile = tmp_path / "nested" / "dir" / "out.csv"
+        with patch.object(anno_exporter, "to_csv"):
+            anno_exporter.save(sample_annotations, "csv", outfile, Mock())
+        assert outfile.parent.is_dir()
+
+
+class TestToRefinebioDataset:
+    """test to_refinebio_dataset, shared identically between both exporters"""
+
+    def test_delegates_to_refinebio_create_dataset(self, anno_exporter, sample_annotations):
+        with patch.object(
+            anno_exporter._refinebio, "create_dataset", return_value={"id": "abc"}
+        ) as mock_create:
+            result = anno_exporter.to_refinebio_dataset(sample_annotations)
+
+        mock_create.assert_called_once_with(sample_annotations)
+        assert result == {"id": "abc"}
+
+
+class TestToNumpy:
+    """test to_numpy, shared identically between both exporters"""
+
+    def test_returns_data_as_numpy(self, anno_exporter, sample_annotations):
+        result = anno_exporter.to_numpy(sample_annotations)
+        assert (result == sample_annotations.data.to_numpy()).all()
+
+    def test_works_for_labels(self, labels_exporter, sample_labels):
+        result = labels_exporter.to_numpy(sample_labels)
+        assert (result == sample_labels.data.to_numpy()).all()
+
+
+class TestSaveTabular:
+    """test _save_tabular (via to_csv), shared - modulo the sort-order fix -
+    between both exporters"""
+
+    def test_output_sorted_by_index_without_geo_metadata(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.csv"
+        anno_exporter.to_csv(sample_annotations, outfile, citation_config, metadata="sample")
+
+        written = pl.read_csv(outfile)
+        assert written["sample"].to_list() == sorted(written["sample"].to_list())
+
+    def test_labels_output_already_sorted_by_index(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.csv"
+        labels_exporter.to_csv(sample_labels, outfile, citation_config, metadata="sample")
+
+        written = pl.read_csv(outfile)
+        assert written["sample"].to_list() == sorted(written["sample"].to_list())
+
+    def test_merges_sra_fields_when_requested(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.csv"
+        anno_exporter.to_csv(
+            sample_annotations, outfile, citation_config, metadata="sample,srr"
+        )
+
+        written = pl.read_csv(outfile)
+        assert "srr" in written.columns
+
+    def test_merges_refinebio_fields_when_requested(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.csv"
+        anno_exporter.to_csv(
+            sample_annotations,
+            outfile,
+            citation_config,
+            metadata="sample,refinebio_sample",
+        )
+
+        written = pl.read_csv(outfile)
+        assert "refinebio_sample" in written.columns
+
+    def test_geo_metadata_branch_sorted_and_merged(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path, monkeypatch
+    ):
+        geo_parquet = tmp_path / "geo.parquet"
+        pl.DataFrame(
+            {
+                "sample": ["GSM1", "GSM2", "GSM3", "GSM4"],
+                "description": ["d1", "d2", "d3", "d4"],
+            }
+        ).write_parquet(geo_parquet)
+        monkeypatch.setattr(
+            "metahq_core.export.base.geo_metadata", lambda level: geo_parquet
+        )
+
+        outfile = tmp_path / "out.csv"
+        anno_exporter.to_csv(
+            sample_annotations, outfile, citation_config, metadata="sample,description"
+        )
+
+        written = pl.read_csv(outfile)
+        assert written["sample"].to_list() == sorted(written["sample"].to_list())
+        assert written.filter(pl.col("sample") == "GSM1")["description"].item() == "d1"
+
+    def test_invalid_fmt_raises_readable_valueerror(
+        self, anno_exporter, sample_annotations, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.yaml"
+        with pytest.raises(ValueError, match=r"Expected fmt in .*, got yaml\.") as exc:
+            anno_exporter._save_tabular(
+                "yaml", sample_annotations, outfile, citation_config, metadata="sample"
+            )
+
+        assert isinstance(exc.value.args[0], str)

--- a/packages/core/tests/test_LabelsExporter.py
+++ b/packages/core/tests/test_LabelsExporter.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for LabelsExporter.to_json and its private helpers - the logic
+that stays specific to LabelsExporter after the shared save/csv/parquet/tsv/
+get_sra behavior is consolidated onto BaseExporter.
+
+Author: Parker Hicks
+Date: 2026-08-10
+"""
+
+import json
+from unittest.mock import Mock
+
+import polars as pl
+import pytest
+
+from metahq_core.curations.labels import Labels
+from metahq_core.export.labels import LabelsExporter
+from metahq_core.export.references import CitationConfig
+
+ANNOTATIONS_DB = {
+    "GSM1": {"accession_ids": {"srr": "SRR1"}},
+    "GSM2": {"accession_ids": {"srr": "SRR2"}},
+    "GSM3": {"accession_ids": {}},
+    "GSM4": {"accession_ids": {"srr": "SRR4"}},
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_annotations_db(monkeypatch):
+    monkeypatch.setattr(
+        "metahq_core.export.base.load_bson", lambda *a, **k: ANNOTATIONS_DB
+    )
+
+
+@pytest.fixture
+def sample_labels():
+    """positive (1), negative (-1), control (2), and unlabeled (0) rows for
+    a disease ontology entity so both bucket branches are exercised."""
+    data = pl.DataFrame({"MONDO:0005148": [1, -1, 2, 0]})
+    ids = pl.DataFrame(
+        {
+            "sample": ["GSM1", "GSM2", "GSM3", "GSM4"],
+            "series": ["GSE1", "GSE1", "GSE2", "GSE1"],
+            "sources": ["KrishnanLab", "KrishnanLab", "KrishnanLab", "KrishnanLab"],
+        }
+    )
+    return Labels(data, ids, index_col="sample", group_cols=("series", "sources"))
+
+
+@pytest.fixture
+def sample_labels_no_controls():
+    """a non-disease entity, which never gets a 'control' bucket."""
+    data = pl.DataFrame({"UBERON:0000948": [1, -1, 1, 0]})
+    ids = pl.DataFrame(
+        {
+            "sample": ["GSM1", "GSM2", "GSM3", "GSM4"],
+            "series": ["GSE1", "GSE1", "GSE2", "GSE1"],
+            "sources": ["KrishnanLab", "KrishnanLab", "KrishnanLab", "KrishnanLab"],
+        }
+    )
+    return Labels(data, ids, index_col="sample", group_cols=("series", "sources"))
+
+
+@pytest.fixture
+def labels_exporter():
+    return LabelsExporter(attribute="disease", level="sample", logger=Mock(), verbose=False)
+
+
+@pytest.fixture
+def citation_config(tmp_path):
+    return CitationConfig(
+        version="1.0.0",
+        terms="disease",
+        attribute="disease",
+        level="sample",
+        species="human",
+        ecode="expert",
+        tech="rna-seq",
+        mode="label",
+        license="all",
+        date="2026-08-10 00:00:00",
+        outfile=tmp_path / "CITATION.txt",
+    )
+
+
+class TestToJson:
+    """test to_json happy paths, bucket structure, and error path"""
+
+    def test_disease_ontology_entity_gets_control_bucket(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        labels_exporter.to_json(sample_labels, outfile, citation_config, metadata=None)
+
+        result = json.loads(outfile.read_text())
+        assert set(result["MONDO:0005148"].keys()) == {"positive", "negative", "control"}
+
+    def test_non_disease_entity_has_no_control_bucket(
+        self, labels_exporter, sample_labels_no_controls, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        labels_exporter.to_json(
+            sample_labels_no_controls, outfile, citation_config, metadata=None
+        )
+
+        result = json.loads(outfile.read_text())
+        assert set(result["UBERON:0000948"].keys()) == {"positive", "negative"}
+
+    def test_labels_placed_in_correct_buckets(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        labels_exporter.to_json(sample_labels, outfile, citation_config, metadata=None)
+
+        result = json.loads(outfile.read_text())
+        entity = result["MONDO:0005148"]
+        assert [next(iter(entry)) for entry in entity["positive"]] == ["GSM1"]
+        assert [next(iter(entry)) for entry in entity["negative"]] == ["GSM2"]
+        assert [next(iter(entry)) for entry in entity["control"]] == ["GSM3"]
+        # GSM4 (label 0) is unlabeled and must not appear in any bucket
+        all_ids = {
+            idx
+            for bucket in entity.values()
+            for entry in bucket
+            for idx in entry
+        }
+        assert "GSM4" not in all_ids
+
+    def test_with_metadata_attaches_requested_fields(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        labels_exporter.to_json(
+            sample_labels, outfile, citation_config, metadata="sample,srr"
+        )
+
+        result = json.loads(outfile.read_text())
+        positive_entry = result["MONDO:0005148"]["positive"][0]
+        assert positive_entry["GSM1"]["srr"] == "SRR1"
+
+    def test_only_index_and_string_metadata_produce_same_shape(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        no_metadata = tmp_path / "no_metadata.json"
+        labels_exporter.to_json(sample_labels, no_metadata, citation_config, metadata=None)
+
+        explicit_index = tmp_path / "explicit_index.json"
+        labels_exporter.to_json(
+            sample_labels, explicit_index, citation_config, metadata="sample"
+        )
+
+        assert json.loads(no_metadata.read_text()) == json.loads(
+            explicit_index.read_text()
+        )
+
+    def test_non_str_non_none_metadata_raises_readable_valueerror(
+        self, labels_exporter, sample_labels, citation_config, tmp_path
+    ):
+        outfile = tmp_path / "out.json"
+        with pytest.raises(ValueError, match=r"Unexpected metadata argument: 123") as exc:
+            labels_exporter.to_json(sample_labels, outfile, citation_config, metadata=123)
+
+        assert isinstance(exc.value.args[0], str)

--- a/uv.lock
+++ b/uv.lock
@@ -1393,7 +1393,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1692,7 +1692,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "requests", specifier = ">=2.30.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "upsetplot", specifier = ">=0.9.0" },
@@ -1748,7 +1748,7 @@ requires-dist = [
     { name = "pytest-benchmark", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
-    { name = "requests", specifier = ">=2.30.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "vulture", marker = "extra == 'dev'" },
 ]
@@ -1767,6 +1767,7 @@ dependencies = [
     { name = "pymongo" },
     { name = "pyyaml" },
     { name = "rank-bm25" },
+    { name = "requests" },
     { name = "rich" },
 ]
 
@@ -1816,6 +1817,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "rank-bm25", specifier = ">=0.2.2" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "vulture", marker = "extra == 'dev'" },
 ]


### PR DESCRIPTION
# What
Refactors the `metahq_core.export` package to consolidate duplicated functions shared across the `AnnotationsExporter` and `LabelsExporter` modules.

# Why
The many methods across the two modules performed the same functionalities, but differed in documentation, type hints, etc. Consolidation simplifies test writing and reduces potential for bugs.

# How
- Moved all methods with the same functionality from the separate exporters into the `BaseCuration` module.
  - The `to_json` method is really the only method that differs between the two exporters since they actually differ in content format.
- Wrote new tests for the new `BaseCuration` shared methods and updated the `AnnotationsExporter` and `LabelsExporter` tests to reflect this refactor. 